### PR TITLE
Add Package-Requires for mark-multiple

### DIFF
--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -4,6 +4,7 @@
 
 ;; Author: Magnar Sveen <magnars@gmail.com>
 ;; Keywords: editing cursors
+;; Package-Requires: ((mark-multiple "1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This addition tells `package.el` that `mark-multiple` must be installed prior to `multiple-cursors`.
