### PR TITLE
Add ;;;###autoload to eval-after-load

### DIFF
--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -131,6 +131,7 @@
 (require 'mc-mark-more)
 (require 'rectangular-region-mode)
 
+;;;###autoload
 (eval-after-load "mark-multiple" '(require 'mc-mark-multiple-integration))
 
 (provide 'multiple-cursors)


### PR DESCRIPTION
I am proposing this commit so that when the package is installed with `package.el` the proper keybindings will be set for integration with mark-multiple.

This needs to be an autoload since for `package.el`, will not load `multiple-cursors.el` automatically unless there is an autoload to do so.  This will just add the entire `eval-after-load` statement to the autoload file so it will be automatically evaluated on startup.
