### PR TITLE
Fix: mc/dump-list loosing old setting

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -513,9 +513,11 @@ for running commands with multiple cursors.")
     (insert "(setq " (symbol-name list-symbol) "\n"
             "      '(")
     (newline-and-indent)
+    (set list-symbol
+         (sort value (lambda (x y) (string-lessp (symbol-name x)
+                                                 (symbol-name y)))))
     (mapc #'(lambda (cmd) (insert (format "%S" cmd)) (newline-and-indent))
-          (sort value (lambda (x y) (string-lessp (symbol-name x)
-                                                  (symbol-name y)))))
+          value)
     (insert "))")
     (newline)))
 


### PR DESCRIPTION
I had strange behavior when adding new functions to .mc-lists.el; it looses setting sometime.  I can't find condition for this to happen, but I think I fixed the bug.

Observe this:

``` cl
(let ((l '("c" "a" "b")))
  (sort l #'string-lessp)
  l)  ; => ("c")
```

If you don't re-set the list, you can loose entries after `sort`.  I think this was what happened.
