### PR TITLE
Prevent byte-compilation warnings 'cl functions

### DIFF
--- a/mc-cycle-cursors.el
+++ b/mc-cycle-cursors.el
@@ -113,4 +113,10 @@
 
 (provide 'mc-cycle-cursors)
 
+
+;; Local Variables:
+;; coding: utf-8
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
 ;;; mc-cycle-cursors.el ends here


### PR DESCRIPTION
Prevents the following senseless warnings:

```
In mc/first-fake-cursor-after:
mc-cycle-cursors.el:76:70:Warning: function `remove-if' from cl package called
    at runtime
mc-cycle-cursors.el:78:64:Warning: function `sort*' from cl package called at
    runtime

In mc/last-fake-cursor-before:
mc-cycle-cursors.el:85:71:Warning: function `remove-if' from cl package called
    at runtime
mc-cycle-cursors.el:87:65:Warning: function `sort*' from cl package called at
    runtime
```
