### PR TITLE
Simplify travis script, and make it work when ECUKES_EMACS has spaces

### DIFF
--- a/run-travis-ci.sh
+++ b/run-travis-ci.sh
@@ -1,20 +1,12 @@
-#!/bin/sh
+#!/bin/sh -e
 
 cd "$(dirname "$0")"
 
-set_default () {
-  eval "
-if [ -z \$$1 ]; then
-  $1=$2
-fi
-"
-}
-
-set_default ECUKES_EMACS "$(which emacs)"
+ECUKES_EMACS=${ECUKES_EMACS:-$(which emacs)}
 
 echo "*** Emacs version ***"
-echo "ECUKES_EMACS =" $(which $ECUKES_EMACS)
-$ECUKES_EMACS --version
+echo "ECUKES_EMACS = $ECUKES_EMACS"
+"$ECUKES_EMACS" --version
 echo
 
 exec ./util/ecukes/ecukes --graphical


### PR DESCRIPTION
Yes, on OS X, one might have:

ECUKES_EMACS='/Applications/Emacs 23.app/Contents/MacOS/Emacs'

(I've separately filed a pull request to fix ecukes' handling of the same case: rejeep/ecukes#80)
