### PR TITLE
Fix mc/dump-list (take 2): it looses old setting

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -505,7 +505,7 @@ for running commands with multiple cursors.")
 
 (defun mc/dump-list (list-symbol)
   "Insert (setq 'LIST-SYMBOL LIST-VALUE) to current buffer."
-  (let ((value (symbol-value list-symbol)))
+  (symbol-macrolet ((value (symbol-value list-symbol)))
     (insert "(setq " (symbol-name list-symbol) "\n"
             "      '(")
     (newline-and-indent)


### PR DESCRIPTION
It seems #40 is not enough.

In the old code, heading part of `value` may lost due to in-place
modification by the `sort` function. `(symbol-value list-symbol)`
must be re-evaluated before passing it to `mapc`.  To do that,
simply replacing `let` to `symbol-macrolet` works.
