### PR TITLE
Adding support for using mc/edit-lines without transient mark mode.

### DIFF
--- a/features/edit-lines.feature
+++ b/features/edit-lines.feature
@@ -42,3 +42,16 @@ Feature: Switching from a multiline region to multiple cursors
     And I go to the front of the word "long"
     And I press "C-S-c C-S-c"
     Then I should have 2 cursors
+
+  Scenario: Edit without using transient mark mode
+    Given I turn off transient-mark-mode
+    And I insert:
+    """
+    hello
+    there
+    """
+    And I go to the front of the word "hello"
+    And I set the mark
+    And I go to the front of the word "there"
+    And I press "C-S-c C-S-c"
+    Then I should have 2 cursors

--- a/mc-edit-lines.el
+++ b/mc-edit-lines.el
@@ -35,7 +35,7 @@
 Starts from mark and moves in straight down or up towards the
 line point is on."
   (interactive)
-  (when (not (use-region-p))
+  (when (not (and mark-active (/= (point) (mark))))
     (error "Mark a set of lines first."))
   (mc/remove-fake-cursors)
   (let* ((col (current-column))


### PR DESCRIPTION
This change makes it possible to use mc/edit-lines without using transient mark mode.  I believe I added a test for this, but since I've never used ecukes before, I'm not 100% sure that it's working correctly.
