### PR TITLE
Add gnu repo to Cask, which is needed for cl-lib on Emacs <24.3

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "multiple-cursors.el")


### PR DESCRIPTION
This fixes the first problem mentioned in #102.
