### PR TITLE
smartparens also does not play well with multiple cursors.

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -424,7 +424,7 @@ So you can paste it in later with `yank-rectangle'."
     (unless (mc--all-equal entries)
       (setq killed-rectangle entries))))
 
-(defvar mc/unsupported-minor-modes '(auto-complete-mode flyspell-mode)
+(defvar mc/unsupported-minor-modes '(auto-complete-mode flyspell-mode smartparens-mode)
   "List of minor-modes that does not play well with multiple-cursors.
 They are temporarily disabled when multiple-cursors are active.")
 


### PR DESCRIPTION
So I added it to the default list of unsupported minor modes.
