### PR TITLE
Add mc/mark-all-dwim to autoloads

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -416,6 +416,7 @@ With prefix, it behaves the same as original `mc/mark-all-like-this'"
         (when (<= (mc/num-cursors) before)
           (mc/mark-all-like-this))))))
 
+;;;###autoload
 (defun mc/mark-all-dwim (arg)
   "Tries even harder to guess what you want to mark all of.
 


### PR DESCRIPTION
Forgot to do that, and it breaks keybindings on first use.
