### PR TITLE
Show appropriate error messages on trying skipping/unmarking commands with no fake cursors

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -107,17 +107,19 @@ Use like case-fold-search, don't recommend setting it globally.")
         (match-point-getter (ecase direction
                               (forwards 'match-beginning)
                               (backwards 'match-end))))
-    (mc/save-excursion
-     (goto-char start-char)
-     (when skip-last
-       (mc/remove-fake-cursor furthest-cursor))
-     (if (funcall search-function re nil t)
-         (progn
-           (push-mark (funcall match-point-getter 0))
-           (when point-out-of-order
-             (exchange-point-and-mark))
-           (mc/create-fake-cursor-at-point))
-       (error "no more matches found.")))))
+    (if (and skip-last (not furthest-cursor))
+        (error "No cursors to be skipped")
+      (mc/save-excursion
+       (goto-char start-char)
+       (when skip-last
+         (mc/remove-fake-cursor furthest-cursor))
+       (if (funcall search-function re nil t)
+           (progn
+             (push-mark (funcall match-point-getter 0))
+             (when point-out-of-order
+               (exchange-point-and-mark))
+             (mc/create-fake-cursor-at-point))
+         (error "no more matches found."))))))
 
 ;;;###autoload
 (defun mc/mark-next-like-this (arg)
@@ -127,7 +129,10 @@ With zero ARG, skip the last one and mark next."
   (interactive "p")
   (if (region-active-p)
       (if (< arg 0)
-          (mc/remove-fake-cursor (mc/furthest-cursor-after-point))
+          (let ((cursor (mc/furthest-cursor-after-point)))
+            (if cursor
+                (mc/remove-fake-cursor cursor)
+              (error "No cursors to be unmarked")))
         (mc/mark-more-like-this (= arg 0) 'forwards))
     (mc/mark-lines arg 'forwards))
   (mc/maybe-multiple-cursors-mode))
@@ -152,7 +157,10 @@ With zero ARG, skip the last one and mark next."
   (interactive "p")
   (if (region-active-p)
       (if (< arg 0)
-          (mc/remove-fake-cursor (mc/furthest-cursor-before-point))
+          (let ((cursor (mc/furthest-cursor-before-point)))
+            (if cursor
+                (mc/remove-fake-cursor cursor)
+              (error "No cursors to be unmarked")))
         (mc/mark-more-like-this (= arg 0) 'backwards))
     (mc/mark-lines arg 'backwards))
   (mc/maybe-multiple-cursors-mode))


### PR DESCRIPTION
When no fake cursors exist, I run `mc/unmark-next-like-this` and get an error message:

```
Wrong type argument: overlayp, nil
```

This is confusing.
This pull request refines error messages raised from `mc/mark-next-like-this`, `mc/mark-previous-like-this` and `mc/mark-more-like-this` when no fake cursors exist.

Suitable tests should be added, but I don't know how ecukes handles errors...
