### PR TITLE
Fixed #131 (allow C-u with mc/insert-numbers)

### DIFF
--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -33,7 +33,8 @@
 (defun mc/insert-numbers (arg)
   "Insert increasing numbers for each cursor, starting at 0 or ARG."
   (interactive "P")
-  (setq mc--insert-numbers-number (or arg 0))
+  (setq mc--insert-numbers-number (or (and arg (prefix-numeric-value arg))
+                                      0))
   (mc/for-each-cursor-ordered
    (mc/execute-command-for-fake-cursor 'mc--insert-number-and-increase cursor)))
 


### PR DESCRIPTION
Fixes so that C-u M-x mc/insert-numbers starts at 4.