### PR TITLE
make mc/mark-next-like-this with nagative ARG to delete a cursor even if the region is not active.

### DIFF
--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -80,6 +80,52 @@ Feature: Marking multiple parts of the buffer
     And I type "more"
     Then I should see "Here's text, more and more"
 
+  Scenario: Removing first cursor without an active region
+    When I insert:
+    """
+    aaa
+    bbb
+    ccc
+    ddd
+    """
+    And I go to the front of the word "bbb"
+    And I press "C->"
+    And I press "C->"
+    And I press "C-- C-<"
+    And I press "C-- C-<"
+    And I type "_"
+    Then I should have 1 cursors
+    And I should see:
+    """
+    aaa
+    bbb
+    ccc
+    _ddd
+    """
+
+  Scenario: Removing last cursor without an active region
+    When I insert:
+    """
+    aaa
+    bbb
+    ccc
+    ddd
+    """
+    And I go to the front of the word "ddd"
+    And I press "C-<"
+    And I press "C-<"
+    And I press "C-- C->"
+    And I press "C-- C->"
+    And I type "_"
+    Then I should have 1 cursors
+    And I should see:
+    """
+    aaa
+    _bbb
+    ccc
+    ddd
+    """
+
   Scenario: Marking all
     When I insert "Here's text, text and text"
     And I select "text"

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -55,7 +55,7 @@
     beg))
 
 (defun mc/furthest-cursor-before-point ()
-  (let ((beg (min (mark) (point)))
+  (let ((beg (if mark-active (min (mark) (point)) (point)))
         furthest)
     (mc/for-each-fake-cursor
      (when (< (mc/cursor-beg cursor) beg)
@@ -64,7 +64,7 @@
     furthest))
 
 (defun mc/furthest-cursor-after-point ()
-  (let ((end (max (mark) (point)))
+  (let ((end (if mark-active (max (mark) (point)) (point)))
         furthest)
     (mc/for-each-fake-cursor
      (when (> (mc/cursor-end cursor) end)
@@ -127,14 +127,15 @@ Use like case-fold-search, don't recommend setting it globally.")
 With negative ARG, delete the last one instead.
 With zero ARG, skip the last one and mark next."
   (interactive "p")
-  (if (region-active-p)
-      (if (< arg 0)
-          (let ((cursor (mc/furthest-cursor-after-point)))
-            (if cursor
-                (mc/remove-fake-cursor cursor)
-              (error "No cursors to be unmarked")))
-        (mc/mark-more-like-this (= arg 0) 'forwards))
-    (mc/mark-lines arg 'forwards))
+  (cond ((< arg 0)
+         (let ((cursor (mc/furthest-cursor-after-point)))
+           (if cursor
+               (mc/remove-fake-cursor cursor)
+             (error "No cursors to be unmarked"))))
+        ((region-active-p)
+         (mc/mark-more-like-this (= arg 0) 'forwards))
+        (t
+         (mc/mark-lines arg 'forwards)))
   (mc/maybe-multiple-cursors-mode))
 
 ;;;###autoload
@@ -155,14 +156,15 @@ With zero ARG, skip the last one and mark next."
 With negative ARG, delete the last one instead.
 With zero ARG, skip the last one and mark next."
   (interactive "p")
-  (if (region-active-p)
-      (if (< arg 0)
-          (let ((cursor (mc/furthest-cursor-before-point)))
-            (if cursor
-                (mc/remove-fake-cursor cursor)
-              (error "No cursors to be unmarked")))
-        (mc/mark-more-like-this (= arg 0) 'backwards))
-    (mc/mark-lines arg 'backwards))
+  (cond ((< arg 0)
+         (let ((cursor (mc/furthest-cursor-before-point)))
+           (if cursor
+               (mc/remove-fake-cursor cursor)
+             (error "No cursors to be unmarked"))))
+        ((region-active-p)
+         (mc/mark-more-like-this (= arg 0) 'backwards))
+        (t
+         (mc/mark-lines arg 'backwards)))
   (mc/maybe-multiple-cursors-mode))
 
 ;;;###autoload


### PR DESCRIPTION
`mc/mark-next-like-this` (`mc/mark-previous-like-this`) does nothing with a nagative argument when the region is not active.
I think it should remove a cursor regardless of the region activity
because we have no means to delete a cursor if the region is not active.
What do you think about it?
