### PR TITLE
Gitignore *.elc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 elpa
+*.elc


### PR DESCRIPTION
When using this multiple-cursors.el repository as a submodule and
using compilation from .el to .elc, git will report the .elc files as
untracked changes in the submodule. Ignoring *.elc files fixes that.
