### PR TITLE
Added mc/mark-all-regexp-in-region

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can [watch an intro to multiple-cursors at Emacs Rocks](http://emacsrocks.co
  - `mc/mark-all-words-like-this`: Like `mc/mark-all-like-this` but only for whole words.
  - `mc/mark-all-symbols-like-this`: Like `mc/mark-all-like-this` but only for whole symbols.
  - `mc/mark-all-in-region`: Prompts for a string to match in the region, adding cursors to all of them.
+ - `mc/mark-all-regexp-in-region`: Prompts for a regexp to match in the region, adding cursors to all of them.
  - `mc/mark-all-like-this-in-defun`: Marks all parts of the current defun that matches the current region.
  - `mc/mark-all-words-like-this-in-defun`: Like `mc/mark-all-like-this-in-defun` but only for whole words.
  - `mc/mark-all-symbols-like-this-in-defun`: Like `mc/mark-all-like-this-in-defun` but only for whole symbols.

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -292,6 +292,28 @@ With zero ARG, skip the last one and mark next."
             (multiple-cursors-mode 1)
           (multiple-cursors-mode 0))))))
 
+;;;###autoload
+(defun mc/mark-all-regexp-in-region (beg end)
+  "Find and mark all the parts in the region matching the given regexp search"
+  (interactive "r")
+  (let ((search (read-from-minibuffer "Mark all regexp in region: "))
+        (case-fold-search nil))
+    (if (string= search "")
+        (message "Mark aborted")
+      (progn
+        (mc/remove-fake-cursors)
+        (goto-char beg)
+        (while (search-forward-regexp search end t)
+          (push-mark (match-beginning 0))
+          (mc/create-fake-cursor-at-point))
+        (let ((first (mc/furthest-cursor-before-point)))
+          (if (not first)
+              (error "Search failed for %S" search)
+            (mc/pop-state-from-overlay first)))
+        (if (> (mc/num-cursors) 1)
+            (multiple-cursors-mode 1)
+          (multiple-cursors-mode 0))))))
+
 (when (not (fboundp 'set-temporary-overlay-map))
   ;; Backport this function from newer emacs versions
   (defun set-temporary-overlay-map (map &optional keep-pred)

--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -75,6 +75,7 @@
 ;;  - `mc/mark-all-words-like-this`: Like `mc/mark-all-like-this` but only for whole words.
 ;;  - `mc/mark-all-symbols-like-this`: Like `mc/mark-all-like-this` but only for whole symbols.
 ;;  - `mc/mark-all-in-region`: Prompts for a string to match in the region, adding cursors to all of them.
+;;  - `mc/mark-all-regexp-in-region`: Prompts for a regexp to match in the region, adding cursors to all of them.
 ;;  - `mc/mark-all-like-this-in-defun`: Marks all parts of the current defun that matches the current region.
 ;;  - `mc/mark-all-words-like-this-in-defun`: Like `mc/mark-all-like-this-in-defun` but only for whole words.
 ;;  - `mc/mark-all-symbols-like-this-in-defun`: Like `mc/mark-all-like-this-in-defun` but only for whole symbols.


### PR DESCRIPTION
This adds the functionality requested in https://github.com/magnars/multiple-cursors.el/issues/114. Creates a version of `mc/mark-all-in-region` which uses `search-forward-regexp` in place of `search-forward`.

I have tested this, and it seems to function as expected.
