### PR TITLE
Adds jedi-mode to list of unsupported minor modes

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -428,7 +428,7 @@ So you can paste it in later with `yank-rectangle'."
     (unless (mc--all-equal entries)
       (setq killed-rectangle entries))))
 
-(defvar mc/unsupported-minor-modes '(auto-complete-mode flyspell-mode)
+(defvar mc/unsupported-minor-modes '(auto-complete-mode flyspell-mode jedi-mode)
   "List of minor-modes that does not play well with multiple-cursors.
 They are temporarily disabled when multiple-cursors are active.")
 


### PR DESCRIPTION
jedi-mode is a minor mode implemented by jedi.el by @tkf, a Python auto-complete package for emacs built on top of Jedi and auto-complete.el. The two primary features of jedi.el's jedi-mode are:
1) Automatically start auto-completion when the dot key is pressed (if configured to do so)
2) Activate key bindings for moving to variable and function
definitions.

Neither make much sense in the context of multiple cursors. In fact, because multiple-cursors disables auto-complete-mode, jedi-mode's complete-on-dot function will fail to run correctly. The end result is
that typing a dot with multiple cursors active results in only one cursor producing the dot.

Because of this bug, and that jedi-mode as a whole doesn't make much sense with multiple cursors, I have added jedi-mode to the list of unsupported minor modes.

Please advise if adding minor modes from external packages to the unsupported list isn't the right way to go, or will otherwise cause problems. Also, some tips on how I could add test cases for this scenario would be appreciated (I'm guessing it's not easy, given how it would require another package to be installed).
