### PR TITLE
"Undo" after leaving mc mode will restore cursors as they was

### DIFF
--- a/features/multiple-cursors-core.feature
+++ b/features/multiple-cursors-core.feature
@@ -65,6 +65,14 @@ Feature: Multiple cursors core
     And I type "!"
     Then I should see "This text! contains the word text! twice"
 
+  Scenario: Undo mode
+    Given I have cursors at "text" in "This text contains the word text twice"
+    When I press "C-g"
+    And I press "M-f"
+    And I press "C-_"
+    And I type "!"
+    Then I should see "This !text contains the word !text twice"
+
   Scenario: Setting and popping mark
     Given I have cursors at "text" in "This text contains the word text twice"
     And I press "C-SPC"


### PR DESCRIPTION
If you accidentaly leave mc mode, you may return to it and restore state of cursors just by pressing C-_ .
Also this is the feature was requested in https://github.com/magnars/multiple-cursors.el/issues/86 .
How this feature implemented: every time when multiple-cursor-mode got disabled, it adds function to restore it state in buffer-undo-list, which is used by 'undo' command. 
This feature works well with regular 'undo' and with 'undo-tree-mode'. It must work with any other undo replacement.
