### PR TITLE
Mark more sexps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can [watch an intro to multiple-cursors at Emacs Rocks](http://emacsrocks.co
  - `mc/mark-previous-like-this`: Adds a cursor and region at the next part of the buffer backwards that matches the current region.
  - `mc/mark-previous-word-like-this`: Like `mc/mark-previous-like-this` but only for whole words.
  - `mc/mark-previous-symbol-like-this`: Like `mc/mark-previous-like-this` but only for whole symbols.
+ - `mc/mark-next-sexps`: Mark the next sexp.
  - `mc/mark-more-like-this-extended`: Use arrow keys to quickly mark/skip next/previous occurances.
  - `mc/add-cursor-on-click`: Bind to a mouse event to add cursors by clicking. See tips-section.
  - `mc/mark-pop`: Set a cursor at the current point and move to the next (different) position on the mark stack.  This allows for fine grained control over the placement of cursors.
@@ -183,7 +184,7 @@ Run the tests with:
 * [Marco Baringer](https://github.com/segv) contributed looping to `mc/cycle` and adding cursors without region for mark-more.
 * [Ivan Andrus](https://github.com/gvol) added showing number of cursors in mode-line, and different options for how to handle short lines in `mc/edit-lines`.
 * [Fuco](https://github.com/Fuco1) added the first version of `mc/mark-all-like-this-dwim`
-* [Zach Kost-Smith](https://github.com/smithzvk) added `mc/mark-pop`
+* [Zach Kost-Smith](https://github.com/smithzvk) added `mc/mark-pop` and `mc/mark-next-sexps`
 * [Maciej Katafiasz](https://github.com/mathrick) added `mc/mark-all-dwim`
 * [Aleksey Fedotov](https://github.com/lexa) added `mc-hide-unmatched-lines-mode`
 

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -133,6 +133,129 @@ Feature: Marking multiple parts of the buffer
     c_cc
     """
 
+  Scenario: Marking S-expressions
+    When I insert:
+    """
+    (let ((x 3) (y (+ 1 1))
+          (z 1))
+      (+ x y z))
+    """
+    And I go to the front of the word "x"
+    And I press "C-b"
+    And I press "C-2 M-x mc/mark-next-sexps"
+    Then I should have 3 cursors
+
+  Scenario: Marking S-expressions
+    When I insert:
+    """
+    (let ((x 3) (y (+ 1 1))
+          (z 1))
+      (+ x y z))
+    """
+    And I go to the front of the word "x"
+    And I press "C-b"
+    And I press "C-2 M-x mc/mark-next-sexps"
+    And I type "!"
+    Then I should have 3 cursors
+    And I should see:
+    """
+    (let (!(x 3)! (y (+ 1 1))!
+          (z 1))
+      (+ x y z))
+    """
+
+  Scenario: Marking S-expressions with comments
+    Given I turn on lisp-mode
+    When I insert:
+    """
+    (let (x
+          ;; y is bound to 2
+          (y (+ 1 1))
+          ;; z is bound to 1
+          (z 1))
+      (+ x y z))
+    """
+    And I go to the front of the word "x"
+    And I press "C-2 M-x mc/mark-next-sexps"
+    And I press "C-M-k"
+    Then I should have 3 cursors
+    And I should see:
+    """
+    (let ()
+      (+ x y z))
+    """
+
+  Scenario: Marking S-expressions with comments backwards
+    Given I turn on lisp-mode
+    When I insert:
+    """
+    (let (x
+          ;; y is bound to 2
+          (y (+ 1 1))
+          ;; z is bound to 1
+          (z 1))
+      (+ x y z))
+    """
+    And I go to the front of the word "x"
+    And I press "C-3 C-M-f C-M-b"
+    And I press "C-2 M-x mc/mark-previous-sexps"
+    And I press "C-M-k"
+    Then I should have 3 cursors
+    And I should see:
+    """
+    (let (
+          ;; y is bound to 2
+          
+          ;; z is bound to 1
+          )
+      (+ x y z))
+    """
+
+  Scenario: Editing S-expressions
+    When I insert:
+    """
+    (let (x y z)
+      (or x y z))
+    """
+    And I go to the front of the word "x"
+    And I press "M-x mc/mark-next-sexps"
+    And I press "C-M-f C-j C-g"
+    And I press "C-2 C-M-u"
+    And I press "M-x indent-sexp"
+    Then I should see:
+    """
+    (let (x
+          y
+          z)
+      (or x y z))
+    """
+
+  Scenario: Editing S-expressions
+    When I insert:
+    """
+    (let (x y z)
+      (+ x y z))
+    """
+    And I go to the front of the word "x"
+    And I press "M-x mc/mark-next-sexps"
+    And I press "C-M-f C-j"
+    And I press "M-x mc/mark-next-sexps"
+    And I press "C-M-b"
+    And I type "("
+    And I press "C-M-f"
+    And I type " "
+    And I press "M-x mc/insert-numbers"
+    And I type ")"
+    And I press "C-g C-2 C-M-u"
+    And I press "M-x indent-sexp"
+    Then I should see:
+    """
+    (let ((x 0)
+          (y 1)
+          (z 2))
+      (+ x y z))
+    """
+
   Scenario: Multiple cursor with shift selection
     When I insert "This text contains the word text twice"
     And I go to the front of the word "text"

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -245,6 +245,27 @@ With zero ARG, skip the last one and mark next."
       (multiple-cursors-mode 1)
     (multiple-cursors-mode 0)))
 
+(defun mc/mark-sexps (num-sexps direction)
+  (dotimes (i num-sexps)
+    (mc/create-fake-cursor-at-point)
+    (ecase direction
+      (forwards (loop do (forward-sexp 1)
+                      while (mc/all-fake-cursors (point) (1+ (point)))))
+      (backwards (loop do (forward-sexp -1)
+                       while (mc/all-fake-cursors (point) (1+ (point))))))))
+
+;;;###autoload
+(defun mc/mark-next-sexps (arg)
+  (interactive "p")
+  (mc/mark-sexps arg 'forwards)
+  (mc/maybe-multiple-cursors-mode))
+
+;;;###autoload
+(defun mc/mark-previous-sexps (arg)
+  (interactive "p")
+  (mc/mark-sexps arg 'backwards)
+  (mc/maybe-multiple-cursors-mode))
+
 (defun mc--select-thing-at-point (thing)
   (let ((bound (bounds-of-thing-at-point thing)))
     (when bound

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -674,6 +674,11 @@ for running commands with multiple cursors.")
                                         capitalize-word
                                         forward-list
                                         backward-list
+                                        backward-up-list
+                                        up-list
+                                        down-list
+                                        forward-sexp
+                                        backward-sexp
                                         hippie-expand
                                         hippie-expand-lines
                                         yank
@@ -682,6 +687,8 @@ for running commands with multiple cursors.")
                                         kill-word
                                         kill-line
                                         kill-whole-line
+                                        kill-sexp
+                                        raise-sexp
                                         backward-kill-word
                                         backward-delete-char-untabify
                                         delete-char delete-forward-char

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -565,6 +565,8 @@ for running commands with multiple cursors.")
                                      mc/edit-ends-of-lines
                                      mc/edit-beginnings-of-lines
                                      mc/mark-next-like-this
+                                     mc/mark-next-sexps
+                                     mc/mark-previous-sexps
                                      mc/mark-next-word-like-this
                                      mc/mark-next-symbol-like-this
                                      mc/mark-previous-like-this


### PR DESCRIPTION
This is a resubmission of pull request #153 which I have closed.  I have rebased the changes on the current head, tidied up the history, and fixed the errors I made in the tests.  Below is the lightly edited text of the original request.

These new functions add the ability to mark s-expressions, which provides a good start towards the ability to mark semantic units of the program (at least for Lisp programs).  I wrote this about a month ago and have found it to be very useful.  While useful in it's own regard, it shines when paired with some code to move the cursors to the start of the next sexp like this:

``` elisp
(defun cycle-sexp-cursor-position (arg)
  "Move the point between the end of the last sexp and the
beginning of the next.

The first time it is called, it will move the point to the
beginning of the next Sexp.  If called again immediately
\(without any intervening commands, it will move the point to
just after the last sexp.

Continued use will cycle through this point immediately after the
last sexp, the point of the next comment following the sexp \(if
applicable), and the start of the next sexp.  These are three
likely places where you might expect the start of the next
logical piece of code.

With negative prefix argument the point will be set to just after
the last sexp.  With C-u, prefix argument 4, the point will be
set to just before the next sexp."
  (interactive "p")
  (cond ((> arg 1)
         (loop while (forward-comment 1)))
        ((< arg 0)
         (loop while (forward-comment -1)))
        ((eql last-command 'cycle-sexp-cursor-position)
         (cond ((looking-at "[ \t\n]")
                (search-forward-regexp "[ \t\n]+"))
               ((= 11 (syntax-class (syntax-after (point))))
                (loop while (forward-comment 1)))
               (t (loop while (forward-comment -1)))))
        (t (loop while (forward-comment 1)))))
```

However, such a utility is outside of the scope of the MC library.

By the way, I personally bind these on "C-M->" and "C-M-<" as it works with the basic rule that adding mod changes from moving by lines or by sexps.
