### PR TITLE
Add missing require to mc-hide-unmatched-lines-mode

### DIFF
--- a/mc-hide-unmatched-lines-mode.el
+++ b/mc-hide-unmatched-lines-mode.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'multiple-cursors-core)
+(require 'mc-mark-more)
 
 (defvar hum/hide-unmatched-lines-mode-map (make-sparse-keymap)
   "Keymap for hide unmatched lines is mainly for rebinding C-g")


### PR DESCRIPTION
The function `hum/hide-unmatched-lines` uses the function
`mc/cursor-beg`, defined in `mc-mark-more.el`, however the feature is
not required leading to failures in some edge case. Fixes #187