### PR TITLE
Enable to specify search word in mc/mark-all-in-region

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -271,10 +271,10 @@ With zero ARG, skip the last one and mark next."
     (mc/mark-all-like-this)))
 
 ;;;###autoload
-(defun mc/mark-all-in-region (beg end)
+(defun mc/mark-all-in-region (beg end &optional search)
   "Find and mark all the parts in the region matching the given search"
   (interactive "r")
-  (let ((search (read-from-minibuffer "Mark all in region: "))
+  (let ((search (or search (read-from-minibuffer "Mark all in region: ")))
         (case-fold-search nil))
     (if (string= search "")
         (message "Mark aborted")


### PR DESCRIPTION
I want to use mc/mark-all-in-region from my command.
Here is a my command:
```lisp
(defun my/mark-all-in-region-like-this ()
  (interactive "r")
  (mc/mark-all-in-region
   (region-beginning)
   (region-end)
   (thing-at-point 'symbol)))
```
1. select region
![_scratch__11](https://cloud.githubusercontent.com/assets/235329/6989372/82b015a2-da95-11e4-920d-7816bd36c8fc.png)
2. my/mark-all-in-region-like-this
![_scratch__10](https://cloud.githubusercontent.com/assets/235329/6989375/8499d1f0-da95-11e4-96ad-e9456b1393ca.png)
Thanks.