### PR TITLE
Respect user-emacs-directory

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -524,7 +524,11 @@ from being executed if in multiple-cursors-mode."
            (overlay-put cursor 'kill-ring kill-ring)
            (overlay-put cursor 'kill-ring-yank-pointer kill-ring-yank-pointer)))))))
 
-(defvar mc/list-file "~/.emacs.d/.mc-lists.el"
+(defvar mc/list-file (expand-file-name
+                      (concat (if (boundp 'user-emacs-directory)
+                                  user-emacs-directory
+                                "~/.emacs.d/")
+                              ".mc-lists.el"))
   "The position of the file that keeps track of your preferences
 for running commands with multiple cursors.")
 


### PR DESCRIPTION
@magnars 
I think the configuration files should be saved under the `user-emacs-directory` if it is set.

Btw is anyone managing this repository currently?
Too many PRs seem forgotten.