### PR TITLE
Add safety ceiling to cursor count at creation

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -157,8 +157,7 @@ highlights the entire width of the window."
   (set-marker (overlay-get o 'point) nil)
   (set-marker (overlay-get o 'mark) nil)
   (mc/delete-region-overlay o)
-  (delete-overlay o)
-  (decf mc--active-cursor-count))
+  (delete-overlay o))
 
 (defun mc/pop-state-from-overlay (o)
   "Restore the state stored in given overlay and then remove the overlay."
@@ -176,11 +175,6 @@ highlights the entire width of the window."
 (defun mc/create-cursor-id ()
   "Returns a unique cursor id"
   (incf mc--current-cursor-id))
-
-(defvar mc--active-cursor-count 1
-  "Number of active cursors.
-This number is incremented by `mc/create-fake-cursor-at-point'
-and decremented by `mc/remove-fake-cursor'.")
 
 (defvar mc--max-cursors-original nil
   "This variable maintains the original maximum number of cursors.
@@ -208,12 +202,11 @@ Saves the current state in the overlay to be restored later."
   (unless mc--max-cursors-original
     (setq mc--max-cursors-original mc/max-cursors))
   (when mc/max-cursors
-    (unless (< mc--active-cursor-count mc/max-cursors)
-      (if (yes-or-no-p (format "%d active cursors. Continue? " mc--active-cursor-count))
+    (unless (< (mc/num-cursors) mc/max-cursors)
+      (if (yes-or-no-p (format "%d active cursors. Continue? " (mc/num-cursors)))
           (setq mc/max-cursors (read-number "Enter a new, temporary maximum: "))
         (mc/remove-fake-cursors)
         (error "Aborted: too many cursors"))))
-  (incf mc--active-cursor-count)
   (let ((overlay (mc/make-cursor-overlay-at-point)))
     (overlay-put overlay 'mc-id (or id (mc/create-cursor-id)))
     (overlay-put overlay 'type 'fake-cursor)

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -462,8 +462,7 @@ The entries are returned in the order they are found in the buffer."
 (defun mc--maybe-set-killed-rectangle ()
   "Add the latest kill-ring entry for each cursor to killed-rectangle.
 So you can paste it in later with `yank-rectangle'."
-  (let ((entries (let ((mc--active-cursor-count -1))
-                   (mc--kill-ring-entries))))
+  (let ((entries (let (mc/max-cursors) (mc--kill-ring-entries))))
     (unless (mc--all-equal entries)
       (setq killed-rectangle entries))))
 


### PR DESCRIPTION
The customizable option `mc/max-cursors` now provides a soft maximum for
the number of cursors allowable.  This is helpful for slower emacsen who
may freeze up when adding too many cursors (as in 'mark-all' variants).

Fix: #206