### PR TITLE
Add mark next/previous dwim

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -598,9 +598,11 @@ for running commands with multiple cursors.")
                                      mc/mark-next-like-this
                                      mc/mark-next-word-like-this
                                      mc/mark-next-symbol-like-this
+                                     mc/mark-next-like-this-dwim
                                      mc/mark-previous-like-this
                                      mc/mark-previous-word-like-this
                                      mc/mark-previous-symbol-like-this
+                                     mc/mark-previous-like-this-dwim
                                      mc/mark-all-like-this
                                      mc/mark-all-words-like-this
                                      mc/mark-all-symbols-like-this
@@ -625,8 +627,12 @@ for running commands with multiple cursors.")
                                      mc/mmlte--down
                                      mc/unmark-next-like-this
                                      mc/unmark-previous-like-this
+                                     mc/unmark-next-like-this-dwim
+                                     mc/unmark-previous-like-this-dwim
                                      mc/skip-to-next-like-this
                                      mc/skip-to-previous-like-this
+                                     mc/skip-to-next-like-this-dwim
+                                     mc/skip-to-previous-like-this-dwim
                                      rrm/switch-to-multiple-cursors
                                      mc-hide-unmatched-lines-mode
                                      hum/keyboard-quit


### PR DESCRIPTION
This commit adds some commands to make multiple cursor more intelligent:
no need to mark thing at point, 
after mark next, cursor position is reserved.

I added `mc/unmark-previous-like-this-dwim`,
`mc/unmark-next-like-this-dwim`,
`mc/skip-to-next-like-this-dwim`,
`mc/skip-to-previous-like-this-dwim`,
which may be redundant, but I can not figure out how to integrate this into mc/mark-more-like-this
