### PR TITLE
Add mc/eval-and-replace function and related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can [watch an intro to multiple-cursors at Emacs Rocks](http://emacsrocks.co
  - `mc/mark-sgml-tag-pair`: Mark the current opening and closing tag.
  - `mc/insert-numbers`: Insert increasing numbers for each cursor, top to bottom.
  - `mc/insert-letters`: Insert increasing letters for each cursor, top to bottom.
+ - `mc/eval-and-replace`: Eval previous sexp and replace with result, mc/id is cursor number.
  - `mc/sort-regions`: Sort the marked regions alphabetically.
  - `mc/reverse-regions`: Reverse the order of the marked regions.
 

--- a/features/eval-and-replace.feature
+++ b/features/eval-and-replace.feature
@@ -1,0 +1,19 @@
+Feature: eval and replace
+
+  Scenario: Three cursors, 0-1-2
+    Given I have cursors at "text" in "This (+ 2 3) text contains the word (+ 2 3) text thrice ((+ 2 (- 3 4)) text)"
+    When I press "H-4"
+    And I press "SPC"
+    Then I should see "This 5 text contains the word 5 text thrice (1 text)"
+
+  Scenario: Three cursors, 0-1-2 test mc/id
+    Given I have cursors at "text" in "This (+ 2 mc/id) text contains the word (identity mc/id) text thrice ((* mc/id 4) text)"
+    When I press "H-4"
+    And I press "SPC"
+    Then I should see "This 2 text contains the word 1 text thrice (8 text)"
+
+  Scenario: Three cursors, 4-5-6
+    Given I have cursors at "text" in "This (+ 2 mc/id) text contains the word (identity mc/id) text thrice ((* mc/id 4) text)"
+    When I press "C-u H-4"
+    And I press "SPC"
+    Then I should see "This 6 text contains the word 5 text thrice (24 text)"

--- a/features/step-definitions/multiple-cursors-steps.el
+++ b/features/step-definitions/multiple-cursors-steps.el
@@ -27,6 +27,9 @@
 (When "^I insert letters$"
       (lambda () (call-interactively 'mc/insert-letters)))
 
+(When "^I eval and replace$"
+      (lambda () (call-interactively 'mc/eval-and-replace)))
+
 (When "^I reverse regions$"
       (lambda () (call-interactively 'mc/reverse-regions)))
 

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -30,6 +30,7 @@
  (global-set-key (kbd "M-#") 'mc/mark-all-in-region)
  (global-set-key (kbd "H-0") 'mc/insert-numbers)
  (global-set-key (kbd "H-3") 'mc/insert-letters)
+ (global-set-key (kbd "H-4") 'mc/eval-and-replace)
  (global-set-key (kbd "H-1") 'mc/reverse-regions)
  (global-set-key (kbd "H-2") 'mc/sort-regions)
  (global-set-key (kbd "C-S-c C-S-c") 'mc/edit-lines)

--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -75,7 +75,8 @@
 
 (defvar mc--insert-letters-number 0)
 
-(defvar mc/id 0)
+(defvar mc/id 0 "The number of the cursor that
+mc/eval-and-replace is acting on. Can be use in evaluated sexp.")
 
 (defun mc--eval-and-replace ()
   (interactive)
@@ -88,6 +89,10 @@
   (setq mc/id (1+ mc/id)))
 
 (defun mc/eval-and-replace (arg)
+  "Eval the sexp before every cursor. The sexp will be deleted
+and replaced with the result of the evaultion. mc/id is a
+variable that holds the number of the cursor evaluating the
+sexp. The starting value for mc/id can be offset using ARG."
   (interactive "P")
   (setq mc/id (or (and arg (prefix-numeric-value arg)) 0))
   (mc/for-each-cursor-ordered

--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -75,6 +75,26 @@
 
 (defvar mc--insert-letters-number 0)
 
+(defvar mc/id 0)
+
+(defun mc--eval-and-replace ()
+  (interactive)
+  (backward-kill-sexp)
+  (condition-case nil
+      (prin1 (eval (read (current-kill 0)))
+             (current-buffer))
+    (error (message "Invalid expression")
+           (insert (current-kill 0))))
+  (setq mc/id (1+ mc/id)))
+
+(defun mc/eval-and-replace (arg)
+  (interactive "P")
+  (setq mc/id (or (and arg (prefix-numeric-value arg)) 0))
+  (mc/for-each-cursor-ordered
+   (mc/execute-command-for-fake-cursor
+    'mc--eval-and-replace
+    cursor)))
+
 (defun mc--insert-letter-and-increase ()
   (interactive)
   (insert (mc--number-to-letters mc--insert-letters-number))

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -614,6 +614,7 @@ for running commands with multiple cursors.")
                                      mc/mark-sgml-tag-pair
                                      mc/insert-numbers
 				     mc/insert-letters
+				     mc/eval-and-replace
                                      mc/sort-regions
                                      mc/reverse-regions
                                      mc/cycle-forward

--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -88,6 +88,7 @@
 ;;  - `mc/mark-sgml-tag-pair`: Mark the current opening and closing tag.
 ;;  - `mc/insert-numbers`: Insert increasing numbers for each cursor, top to bottom.
 ;;  - `mc/insert-letters`: Insert increasing letters for each cursor, top to bottom.
+;;  - `mc/eval-and-replace`: Eval previous sexp and replace with result, mc/id is cursor number.
 ;;  - `mc/sort-regions`: Sort the marked regions alphabetically.
 ;;  - `mc/reverse-regions`: Reverse the order of the marked regions.
 


### PR DESCRIPTION
@magnars this feature never existed and I didn't know if it was because there was some opposition to it in the past or if it never felt necessary because of `mc/insert-numbers` but issue #237 mentions something of this nature and I thought to implement it. The variable that changes is `mc/id`. I also added the necessary tests
