### PR TITLE
Modified mc/mark-lines to allow skipping

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -227,13 +227,15 @@ With zero ARG, skip the last one and mark next."
     (mc/mark-previous-like-this arg)))
 
 (defun mc/mark-lines (num-lines direction)
-  (dotimes (i num-lines)
+  (dotimes (i (if (= num-lines 0) 1 num-lines))
     (mc/save-excursion
      (let ((furthest-cursor (cl-ecase direction
 			      (forwards  (mc/furthest-cursor-after-point))
 			      (backwards (mc/furthest-cursor-before-point)))))
-       (if (overlayp furthest-cursor)
-	   (goto-char (overlay-get furthest-cursor 'point))))
+       (when (overlayp furthest-cursor)
+         (goto-char (overlay-get furthest-cursor 'point))
+         (when (= num-lines 0)
+           (mc/remove-fake-cursor furthest-cursor))))
      (cl-ecase direction
        (forwards (next-logical-line 1 nil))
        (backwards (previous-logical-line 1 nil)))


### PR DESCRIPTION
This is a fix to `mc/mark-lines` which allows it to do a skip operation when using `mc/mark-more-like-this-extended`.  The current behavior is to do nothing when pressing the arrow key corresponding to "skip."

This fix addresses the complaint in #100, and makes the behavior of the command more consistent between having a region selected and having no region selected.