### PR TITLE
When cursor-type is bar, mc/cursors appear as bars

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -35,6 +35,11 @@
   "The face used for fake cursors"
   :group 'multiple-cursors)
 
+(defface mc/cursor-bar-face
+  `((t (:height 1 :background ,(face-attribute 'cursor :background))))
+  "The face used for fake cursors if the cursor-type is bar"
+  :group 'multiple-cursors)
+
 (defface mc/region-face
   '((t :inherit region))
   "The face used for fake regions"
@@ -98,16 +103,26 @@
        (set-marker ,p nil)
        (set-marker ,s nil))))
 
+(defun mc/cursor-is-bar ()
+  "returns true if the cursor is a bar"
+  (cond ((equalp cursor-type 'bar) t)
+   ((when (listp cursor-type) (equalp (car cursor-type) 'bar)) t)
+   (t nil)))
+
 (defun mc/make-cursor-overlay-at-eol (pos)
   "Create overlay to look like cursor at end of line."
   (let ((overlay (make-overlay pos pos nil nil nil)))
-    (overlay-put overlay 'after-string (propertize " " 'face 'mc/cursor-face))
+    (if (mc/cursor-is-bar)
+	(overlay-put overlay 'before-string (propertize "|" 'face 'mc/cursor-bar-face))
+      (overlay-put overlay 'after-string (propertize " " 'face 'mc/cursor-face)))
     overlay))
 
 (defun mc/make-cursor-overlay-inline (pos)
   "Create overlay to look like cursor inside text."
   (let ((overlay (make-overlay pos (1+ pos) nil nil nil)))
-    (overlay-put overlay 'face 'mc/cursor-face)
+    (if (mc/cursor-is-bar)
+	(overlay-put overlay 'before-string (propertize "|" 'face 'mc/cursor-bar-face))
+      (overlay-put overlay 'face 'mc/cursor-face))
     overlay))
 
 (defun mc/make-cursor-overlay-at-point ()


### PR DESCRIPTION
The bar cursor is created directly in c so there is no way for us to create a bar cursor in the same way that emacs proper does, Those functions are not revealed to us through the lisp api. Therefore a hack around had to be found. AFAIK there is no way to display and image or text on top of the buffer without shifting any other characters. For that reason I opted to create a 1px thick line of the same color as the cursor that would act as the virtual cursor. The width of the line can be editted but by default it is one. 

This commit and pull request are in relation to https://github.com/magnars/multiple-cursors.el/issues/215 with @mrkkrp and @apchamberlain. I don't use the bar cursor but if you guys would be willing to try it out I think it should be suitable.

@magnars I didn't know how to test this but no tests failed so it seems good to go if people who use this type of cursor are happy with it