### PR TITLE
Use cl-equalp instead of cl alias equalp (fixes #258).

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -105,8 +105,8 @@
 
 (defun mc/cursor-is-bar ()
   "returns true if the cursor is a bar"
-  (cond ((equalp cursor-type 'bar) t)
-   ((when (listp cursor-type) (equalp (car cursor-type) 'bar)) t)
+  (cond ((cl-equalp cursor-type 'bar) t)
+   ((when (listp cursor-type) (cl-equalp (car cursor-type) 'bar)) t)
    (t nil)))
 
 (defun mc/make-cursor-overlay-at-eol (pos)


### PR DESCRIPTION
The original suggestion was to require cl, but the proper fix is to use the cl-lib version of the function rather than its deprecated alias.