### PR TITLE
Use eq instead of equalp

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -105,8 +105,8 @@
 
 (defun mc/cursor-is-bar ()
   "returns true if the cursor is a bar"
-  (cond ((equalp cursor-type 'bar) t)
-   ((when (listp cursor-type) (equalp (car cursor-type) 'bar)) t)
+  (cond ((eq cursor-type 'bar) t)
+   ((when (listp cursor-type) (eq (car cursor-type) 'bar)) t)
    (t nil)))
 
 (defun mc/make-cursor-overlay-at-eol (pos)


### PR DESCRIPTION
In this case, we're comparing symbols, so `eq` is perfectly adequate.

`equalp` is only available if the `cl` library has been loaded (it's known as `cl-equalp` in `cl-lib`), so let's avoid introducing a dependency on that.