### PR TITLE
Add ivy-done to the commands that are only executed once by default

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -660,6 +660,7 @@ for running commands with multiple cursors."
                                      hum/unhide-invisible-overlays
                                      save-buffer
                                      ido-exit-minibuffer
+                                     ivy-done
                                      exit-minibuffer
                                      minibuffer-complete-and-exit
                                      execute-extended-command


### PR DESCRIPTION
ivy-done is the value of this-original-command when invoking mc/ functions when ivy mode is active.