### PR TITLE
Fix Backspace for Smartparens

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -774,7 +774,7 @@ for running commands with multiple cursors."
                                         subword-downcase
                                         er/expand-region
                                         er/contract-region
-					sp-backward-delete-char
+                                        sp-backward-delete-char
                                         smart-forward
                                         smart-backward
                                         smart-up

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -774,6 +774,7 @@ for running commands with multiple cursors."
                                         subword-downcase
                                         er/expand-region
                                         er/contract-region
+					sp-backward-delete-char
                                         smart-forward
                                         smart-backward
                                         smart-up


### PR DESCRIPTION
Hi! 

Thanks for a great plugin! I found that Backspace does not work well when Smartparens Mode is on. 
Here's an addition to default commands allowed to run for all cursors.

All the best,

szw