### PR TITLE
added functions mc/split-region[-regexp]

### DIFF
--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -121,7 +121,11 @@ Feature: Marking multiple parts of the buffer
     And I go to the front of the word "aaa"
     And I press "C->"
     And I press "C->"
+    And I press "C-SPC"
+    And I press "C-e"
+    And I press "C-w"
     And I type "_"
+    And I press "C-y"
     Then I should have 3 cursors
     And I should see:
     """

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -126,8 +126,7 @@ Feature: Marking multiple parts of the buffer
     And I press "C-w"
     And I type "_"
     And I press "C-y"
-    Then I should have 3 cursors
-    And I should see:
+    Then I should see:
     """
     _aaa
     _bbb

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -118,13 +118,14 @@ Feature: Marking multiple parts of the buffer
     bbb
     ccc
     """
-    And I go to the front of the word "bbb"
+    And I go to the front of the word "aaa"
+    And I press "C->"
     And I press "C->"
     And I type "_"
-    Then I should have 2 cursors
+    Then I should have 3 cursors
     And I should see:
     """
-    aaa
+    _aaa
     _bbb
     _ccc
     """

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -111,6 +111,29 @@ Feature: Marking multiple parts of the buffer
     Then I should have 2 cursors
     And I should see "Here's more, more and text"
 
+  Scenario: Separate kills
+    When I insert:
+    """
+    aaa
+    bbb
+    ccc
+    """
+    And I go to the front of the word "aaa"
+    And I press "C->"
+    And I press "C->"
+    And I press "C-SPC"
+    And I press "C-e"
+    And I press "C-w"
+    And I type "_"
+    And I press "C-y"
+    Then I should have 3 cursors
+    And I should see:
+    """
+    _aaa
+    _bbb
+    _ccc
+    """
+
   Scenario: Splitting region on string
     When I insert "one,two,three,four,five"
     And I select "one,two,three,four,five"

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -118,18 +118,13 @@ Feature: Marking multiple parts of the buffer
     bbb
     ccc
     """
-    And I go to the front of the word "aaa"
+    And I go to the front of the word "bbb"
     And I press "C->"
-    And I press "C->"
-    And I press "C-SPC"
-    And I press "C-e"
-    And I press "C-w"
     And I type "_"
-    And I press "C-y"
-    Then I should have 3 cursors
+    Then I should have 2 cursors
     And I should see:
     """
-    _aaa
+    aaa
     _bbb
     _ccc
     """

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -111,6 +111,28 @@ Feature: Marking multiple parts of the buffer
     Then I should have 2 cursors
     And I should see "Here's more, more and text"
 
+  Scenario: Splitting region on string
+    When I insert "one,two,three,four,five"
+    And I select "one,two,three,four,five"
+    And I press "H-4 , <return>"
+    And I press "C-w"
+    And I type "x"
+    And I press "C-y"
+    and I type "y"
+    Then I should have 5 cursors
+    And I should see "xoney,xtwoy,xthreey,xfoury,xfivey"
+
+  Scenario: Splitting region on regexp
+    When I insert "one-W-two-X-three-Y-four-Z-five"
+    And I select "one-W-two-X-three-Y-four-Z-five"
+    And I press "H-$ -[A-Z]- <return>"
+    And I press "C-w"
+    And I type "x"
+    And I press "C-y"
+    and I type "y"
+    Then I should have 5 cursors
+    And I should see "xoney-W-xtwoy-X-xthreey-Y-xfoury-Z-xfivey"
+
   Scenario: Marking without an active region
     When I insert:
     """

--- a/features/mark-more.feature
+++ b/features/mark-more.feature
@@ -111,28 +111,6 @@ Feature: Marking multiple parts of the buffer
     Then I should have 2 cursors
     And I should see "Here's more, more and text"
 
-  Scenario: Separate kills
-    When I insert:
-    """
-    aaa
-    bbb
-    ccc
-    """
-    And I go to the front of the word "aaa"
-    And I press "C->"
-    And I press "C->"
-    And I press "C-SPC"
-    And I press "C-e"
-    And I press "C-w"
-    And I type "_"
-    And I press "C-y"
-    Then I should see:
-    """
-    _aaa
-    _bbb
-    _ccc
-    """
-
   Scenario: Splitting region on string
     When I insert "one,two,three,four,five"
     And I select "one,two,three,four,five"

--- a/features/multiple-cursors-core.feature
+++ b/features/multiple-cursors-core.feature
@@ -16,7 +16,9 @@ Feature: Multiple cursors core
   Scenario: Separate kill-rings
     Given I have cursors at "text" in "This text contains the word text twice"
     When I press "M-f"
-    And I press "M-d"
+    And I press "C-SPC"
+    And I press "M-f"
+    And I press "C-w"
     And I press "M-b"
     And I press "C-y"
     Then I should see "This  containstext the word  twicetext"
@@ -25,7 +27,9 @@ Feature: Multiple cursors core
     Given I have cursors at "text" in "This text contains the word text twice"
     When I press "M-d"
     And I press "C-f"
-    And I press "M-d"
+    And I press "C-SPC"
+    And I press "M-f"
+    And I press "C-w"
     And I press "C-y M-y"
     Then I should see "This  text the word  text"
 

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -34,6 +34,8 @@
  (global-set-key (kbd "H-3") 'mc/insert-letters)
  (global-set-key (kbd "H-1") 'mc/reverse-regions)
  (global-set-key (kbd "H-2") 'mc/sort-regions)
+ (global-set-key (kbd "H-4") 'mc/split-region)
+ (global-set-key (kbd "H-$") 'mc/split-region-regexp)
  (global-set-key (kbd "C-S-c C-S-c") 'mc/edit-lines)
  (global-set-key (kbd "H-SPC") 'set-rectangular-region-anchor)
  (switch-to-buffer


### PR DESCRIPTION
This commit adds the `mc/split-region` and `mc/split-region-regexp` commands as requested and discussed in #292 