### PR TITLE
Added mc/interactive-repeating-commands

### DIFF
--- a/features/repeat-command.feature
+++ b/features/repeat-command.feature
@@ -1,0 +1,37 @@
+Feature: Repeat last interactive command for fake cursors (mc/repeat-command)
+
+  Scenario: Clone insert-char from M-x
+    Given I have cursors at "text" in "This text contains the word text thrice (text)"
+    When I start an action chain
+    When I press "M-x"
+    And I type "insert-char"
+    And I press "RET"
+    And I type "21"
+    And I press "RET"
+    And I press "C-:"
+    And I press "y"
+    And I execute the action chain
+    Then I should see "This !text contains the word !text thrice (!text)"
+
+  Scenario: Clone insert-char from M-:
+    Given I have cursors at "text" in "This text contains the word text thrice (text)"
+    When I start an action chain
+    When I press "M-:"
+    And I type "(insert-char (+ 40 2))"
+    And I press "RET"
+    And I press "C-:"
+    And I press "y"
+    And I execute the action chain
+    Then I should see "This *text contains the word *text thrice (*text)"
+
+  Scenario: Disable prompt
+    Given I have cursors at "text" in "This text/0000 contains the word text/1111 thrice (text/2222)"
+    When I set mc/always-repeat-command to t
+    When I start an action chain
+    And I press "M-x"
+    And I type "zap-to-char"
+    And I press "RET"
+    And I press "/"
+    And I press "C-:"
+    And I execute the action chain
+    Then I should see "This 0000 contains the word 1111 thrice (2222)"

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -416,7 +416,6 @@ the original cursor, to inform about the lack of support."
                   (message "%S is not supported with multiple cursors%s"
                            original-command
                            (get original-command 'mc--unsupported))
-
                 (when (and original-command
                            (not (memq original-command mc--default-cmds-to-run-once))
                            (not (memq original-command mc/cmds-to-run-once))
@@ -461,7 +460,7 @@ multiple cursors editing.")
   (setq mc/keymap (make-sparse-keymap))
   (define-key mc/keymap (kbd "C-g") 'mc/keyboard-quit)
   (define-key mc/keymap (kbd "<return>") 'multiple-cursors-mode)
-  (define-key mc/keymap (kbd "C-x :") 'mc/repeat-command)
+  (define-key mc/keymap (kbd "C-:") 'mc/repeat-command)
   (when (fboundp 'phi-search)
     (define-key mc/keymap (kbd "C-s") 'phi-search))
   (when (fboundp 'phi-search-backward)
@@ -668,6 +667,7 @@ for running commands with multiple cursors."
                                      mc/skip-to-previous-like-this
                                      rrm/switch-to-multiple-cursors
                                      mc-hide-unmatched-lines-mode
+                                     mc/repeat-command
                                      hum/keyboard-quit
                                      hum/unhide-invisible-overlays
                                      save-buffer

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -330,6 +330,11 @@ cursor with updated info."
   :type '(boolean)
   :group 'multiple-cursors)
 
+(defcustom mc/always-repeat-command nil
+  "Disables confirmation for `mc/repeat-command' command."
+  :type '(boolean)
+  :group 'multiple-cursors)
+
 (defun mc/prompt-for-inclusion-in-whitelist (original-command)
   "Asks the user, then adds the command either to the once-list or the all-list."
   (let ((all-p (y-or-n-p (format "Do %S for all cursors?" original-command))))
@@ -445,7 +450,8 @@ you should disable multiple-cursors-mode."
 (defun mc/repeat-command ()
   "Run last command from `command-history' for every fake cursor."
   (interactive)
-  (when (y-or-n-p (format "[mc] repeat complex command: %s? " (caar command-history)))
+  (when (or mc/always-repeat-command
+            (y-or-n-p (format "[mc] repeat complex command: %s? " (caar command-history))))
     (mc/execute-command-for-all-fake-cursors
      (lambda () (interactive)
        (cl-letf (((symbol-function 'read-from-minibuffer)

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -427,17 +427,14 @@ the original cursor, to inform about the lack of support."
 
                 (when (and original-command
                            (memq original-command mc/interactive-repeating-commands))
-                  (setq original-command nil)
-                  (let ((ch (caar command-history))
+                  (let ((ch (car command-history))
                         (rk (car (last (append (recent-keys) nil)))))
                     (when (and (not (eq rk mc--interactive-repeating-quit))
                                ;; (not (eq this-command 'abort-recursive-edit))
-                               (y-or-n-p (format "[mc] repeat complex command: %s? " ch)))
+                               (y-or-n-p (format "[mc] repeat complex command: %s? " (car ch))))
                       (mc/execute-command-for-all-fake-cursors
-                       (lambda () (interactive)
-                         (cl-letf (((symbol-function 'read-from-minibuffer)
-                                    (lambda (p &optional i k r h d m) (read i))))
-                           (repeat-complex-command 0)))))))
+                       (lambda () (interactive) (eval ch)))))
+                  (setq original-command nil))
 
                 (when (and original-command
                            (not (memq original-command mc--default-cmds-to-run-once))

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -710,7 +710,8 @@ for running commands with multiple cursors."
                                      windmove-left
                                      windmove-right
                                      windmove-up
-                                     windmove-down))
+                                     windmove-down
+                                     repeat-complex-command))
 
 (defvar mc--default-cmds-to-run-for-all nil
   "Default set of commands that should be mirrored by all cursors")

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -443,6 +443,16 @@ you should disable multiple-cursors-mode."
       (multiple-cursors-mode 0)
     (deactivate-mark)))
 
+(defun mc/repeat-command ()
+  "Run last command from `command-history' for every fake cursor."
+  (interactive)
+  (when (y-or-n-p (format "[mc] repeat complex command: %s? " (caar command-history)))
+    (mc/execute-command-for-all-fake-cursors
+     (lambda () (interactive)
+       (cl-letf (((symbol-function 'read-from-minibuffer)
+                  (lambda (p &optional i k r h d m) (read i))))
+         (repeat-complex-command 0))))))
+
 (defvar mc/keymap nil
   "Keymap while multiple cursors are active.
 Main goal of the keymap is to rebind C-g and <return> to conclude
@@ -451,6 +461,7 @@ multiple cursors editing.")
   (setq mc/keymap (make-sparse-keymap))
   (define-key mc/keymap (kbd "C-g") 'mc/keyboard-quit)
   (define-key mc/keymap (kbd "<return>") 'multiple-cursors-mode)
+  (define-key mc/keymap (kbd "C-x :") 'mc/repeat-command)
   (when (fboundp 'phi-search)
     (define-key mc/keymap (kbd "C-s") 'phi-search))
   (when (fboundp 'phi-search-backward)
@@ -665,6 +676,7 @@ for running commands with multiple cursors."
                                      exit-minibuffer
                                      minibuffer-complete-and-exit
                                      execute-extended-command
+                                     eval-expression
                                      undo
                                      redo
                                      undo-tree-undo

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -330,14 +330,6 @@ cursor with updated info."
   :type '(boolean)
   :group 'multiple-cursors)
 
-(defvar mc--interactive-repeating-quit ?\C-g)
-(defcustom mc/interactive-repeating-commands nil
-  "Repeats last interactive command for every fake cursor after this functions
-   are called. Command is taken from `command-history' and caller runs once.
-   Suggested values are `execute-extended-command', `eval-expression' and `helm-M-x'."
-  :type '(list)
-  :group 'multiple-cursors)
-
 (defun mc/prompt-for-inclusion-in-whitelist (original-command)
   "Asks the user, then adds the command either to the once-list or the all-list."
   (let ((all-p (y-or-n-p (format "Do %S for all cursors?" original-command))))
@@ -424,17 +416,6 @@ the original cursor, to inform about the lack of support."
                   (message "%S is not supported with multiple cursors%s"
                            original-command
                            (get original-command 'mc--unsupported))
-
-                (when (and original-command
-                           (memq original-command mc/interactive-repeating-commands))
-                  (let ((ch (car command-history))
-                        (rk (car (last (append (recent-keys) nil)))))
-                    (when (and (not (eq rk mc--interactive-repeating-quit))
-                               ;; (not (eq this-command 'abort-recursive-edit))
-                               (y-or-n-p (format "[mc] repeat complex command: %s? " (car ch))))
-                      (mc/execute-command-for-all-fake-cursors
-                       (lambda () (interactive) (eval ch)))))
-                  (setq original-command nil))
 
                 (when (and original-command
                            (not (memq original-command mc--default-cmds-to-run-once))


### PR DESCRIPTION
Asks for re-running last interactive command from `command-history` on all fake cursors when enabled. It results better handling of `M-x`, `M-:` and `helm-M-x`.