### PR TITLE
Do not signal error in case of exactly one match

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -396,7 +396,7 @@ With zero ARG, skip the last one and mark next."
         (while (search-forward search end t)
           (push-mark (match-beginning 0))
           (mc/create-fake-cursor-at-point))
-        (let ((first (car (mc/all-fake-cursors))))
+        (let ((first (car (last (mc/all-fake-cursors)))))
           (if (not first)
               (error "Search failed for %S" search)
             (mc/pop-state-from-overlay first)))

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -396,7 +396,7 @@ With zero ARG, skip the last one and mark next."
         (while (search-forward search end t)
           (push-mark (match-beginning 0))
           (mc/create-fake-cursor-at-point))
-        (let ((first (mc/furthest-cursor-before-point)))
+        (let ((first (car (mc/all-fake-cursors))))
           (if (not first)
               (error "Search failed for %S" search)
             (mc/pop-state-from-overlay first)))


### PR DESCRIPTION
This is the same error that was reported in #293 but without using regexp search.

@nispio Could you please review this solution? I think it's a lot simpler but maybe does not work exactly the same, I can't quite tell.