### PR TITLE
Explicitly require `mc-mark-more`.

### DIFF
--- a/mc-cycle-cursors.el
+++ b/mc-cycle-cursors.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'multiple-cursors-core)
+(require 'mc-mark-more)
 
 (defun mc/next-fake-cursor-after-point ()
   (let ((pos (point))

--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -28,6 +28,7 @@
 ;;; Code:
 
 (require 'multiple-cursors-core)
+(require 'mc-mark-more)
 
 (defcustom mc/insert-numbers-default 0
   "The default number at which to start counting for


### PR DESCRIPTION
`mc/cursor-beg` and `-end` exist in `mc-mark-more` and can fail to be
loaded when using deferred loading.