### PR TITLE
mc/split-region

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -723,10 +723,7 @@ This can be thought of as an inverse to `mc/mark-all-in-region'."
           (push-mark (match-end 0)))
         (unless (= (point) end)
           (goto-char end))
-        (mc/create-fake-cursor-at-point)
-        (if (> (mc/num-cursors) 1)
-            (multiple-cursors-mode 1)
-          (multiple-cursors-mode 0))))))
+        (mc/maybe-multiple-cursors-mode)))))
 
 (provide 'mc-mark-more)
 


### PR DESCRIPTION
An update to #341.

Removed extra fake cursor at end: Using the example given in the PR, a selection of this:

`|(mc/create-fake-cursor-at-point)<`

and then running `mc/insert-numbers` creates

`(mc/create0-fake1-cursor2-at3-point)4`

Cursor 4 is required, since this function is splitting the selected region into seperate marked regions. For example, splitting a region with only one seperator results in two cursors since there are now two regions. Just thought I should clarify this behavior since the previous PR wanted behavior where this function would only give three cursors. 

Also, I substituted the end logic about `multiple-cursors-mode` into an existing function that does the same behavior (`mc/maybe-multiple-cursors-mode`). 

 