### PR TITLE
format string support for inserting numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can [watch an intro to multiple-cursors at Emacs Rocks](http://emacsrocks.co
  - `set-rectangular-region-anchor`: Think of this one as `set-mark` except you're marking a rectangular region.
  - `mc/mark-sgml-tag-pair`: Mark the current opening and closing tag.
  - `mc/insert-numbers`: Insert increasing numbers for each cursor, top to bottom.
+ - `mc/insert-numbers-with-format`: Insert increasing numbers for each cursor using the provided format string, top to bottom.
  - `mc/insert-letters`: Insert increasing letters for each cursor, top to bottom.
  - `mc/sort-regions`: Sort the marked regions alphabetically.
  - `mc/reverse-regions`: Reverse the order of the marked regions.

--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -38,18 +38,29 @@
 (defvar mc--insert-numbers-number 0)
 
 ;;;###autoload
-(defun mc/insert-numbers (arg)
+(defun mc/insert-numbers-with-format (first-number format-string)
+  "Insert increasing numbers for each cursor, starting at
+`mc/insert-numbers-default' or ARG. A `format` compatible
+format string is queried as input parameter"
+  (interactive "P\nsformat string: ")
+  (setq mc--insert-numbers-number (or (and first-number (prefix-numeric-value first-number))
+                                      mc/insert-numbers-default))
+  (mc/for-each-cursor-ordered
+   (mc/execute-command-for-fake-cursor
+    (lambda () (interactive)
+      (funcall (apply-partially 'mc--insert-number-and-increase format-string)))
+    cursor)))
+
+;;;###autoload
+(defun mc/insert-numbers (first-number)
   "Insert increasing numbers for each cursor, starting at
 `mc/insert-numbers-default' or ARG."
   (interactive "P")
-  (setq mc--insert-numbers-number (or (and arg (prefix-numeric-value arg))
-                                      mc/insert-numbers-default))
-  (mc/for-each-cursor-ordered
-   (mc/execute-command-for-fake-cursor 'mc--insert-number-and-increase cursor)))
+  (mc/insert-numbers-with-format first-number "%d"))
 
-(defun mc--insert-number-and-increase ()
+(defun mc--insert-number-and-increase (format-string)
   (interactive)
-  (insert (number-to-string mc--insert-numbers-number))
+  (insert (format format-string mc--insert-numbers-number))
   (setq mc--insert-numbers-number (1+ mc--insert-numbers-number)))
 
 (defun mc--ordered-region-strings ()

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -696,6 +696,7 @@ for running commands with multiple cursors."
                                      mc/mark-all-dwim
                                      mc/mark-sgml-tag-pair
                                      mc/insert-numbers
+                                     mc/insert-numbers-with-format
 				     mc/insert-letters
                                      mc/sort-regions
                                      mc/reverse-regions


### PR DESCRIPTION
In a few occasions, for aesthetic purposes, I needed `mc/insert-numbers` to insert fixed-width numbers: like `000`, `001`, `002`, etc. I could not find any good way to do so, except editing the source files directly.

This patch adds support for it, and a little more. Users can specify a format string to have control over the format of the inserted number, like `%03d`.

A new `interactive` function is introduced: `mc/insert-numbers-with-format` for this purpose. The original `mc/insert-numbers` works the same way as before.

Similarly to `mc/insert-numbers`, prefix argument specifies the first number to inserted for `mc/insert-numbers-with-format`. The new format-string parameter is read using `IO`.

What do you think?