### PR TITLE
Load mc-cycle-cursors and mc-hide-unmatched-lines-mode after loading multiple-cursors-core

### DIFF
--- a/mc-hide-unmatched-lines-mode.el
+++ b/mc-hide-unmatched-lines-mode.el
@@ -1,4 +1,4 @@
-;;; mc-hide-unmatched-lines.el
+;;; mc-hide-unmatched-lines-mode.el
 
 ;; Copyright (C) 2014 Aleksey Fedotov
 
@@ -103,5 +103,6 @@ mode. To leave this mode press <return> or \"C-g\""
 (defun hum/unhide-unmatched-lines ()
   (remove-overlays nil nil hum/invisible-overlay-name t))
 
-(provide 'mc-hide-unmatched-lines-mode)
 (define-key mc/keymap (kbd "C-'") 'mc-hide-unmatched-lines-mode)
+
+(provide 'mc-hide-unmatched-lines-mode)

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -844,6 +844,8 @@ for running commands with multiple cursors."
   "Commands to run for all cursors in multiple-cursors-mode")
 
 (provide 'multiple-cursors-core)
+(require 'mc-cycle-cursors)
+(require 'mc-hide-unmatched-lines-mode)
 
 ;; Local Variables:
 ;; coding: utf-8

--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -191,12 +191,10 @@
   :group 'editing)
 
 (require 'mc-edit-lines)
-(require 'mc-cycle-cursors)
 (require 'mc-mark-more)
 (require 'mc-mark-pop)
 (require 'rectangular-region-mode)
 (require 'mc-separate-operations)
-(require 'mc-hide-unmatched-lines-mode)
 
 (provide 'multiple-cursors)
 


### PR DESCRIPTION
Currently just invoking autoloaded commands (such as `mc/mark-all-like-this`) doesn't load `mc-cycle-cursors` and `mc-hide-unmatched-lines-mode`.

Putting `(require 'multiple-cursors)` in init file solves this but this makes autoloading useless.

So this PR makes `mc-cycle-cursors` and `mc-hide-unmatched-lines-mode` loaded after loading `multiple-cursors-core`.