### PR TITLE
Make `mc/cursor-bar-face` inherit `cursor`.

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -36,7 +36,7 @@
   :group 'multiple-cursors)
 
 (defface mc/cursor-bar-face
-  `((t (:height 1 :background ,(face-attribute 'cursor :background))))
+  `((t (:height 1 :inherit cursor)))
   "The face used for fake cursors if the cursor-type is bar"
   :group 'multiple-cursors)
 


### PR DESCRIPTION
Making `mc/cursor-bar-face`'s background color static may cause fake cursors to be unreadable when another theme whose background has the same color is loaded.

For example, when current theme's background color is black and `cursor` is white, `mc/cursor-bar-face`'s background is statically determined as white.
When we load another theme which has a bright background, fake cursors will be invisible since are also white.
This commit makes `mc/cursor-bar-face` bound to `cursor`, so fake cursors won't be invisible later.