### PR TITLE
Minor backward compatibility fix to remove warning

### DIFF
--- a/mc-cycle-cursors.el
+++ b/mc-cycle-cursors.el
@@ -88,7 +88,11 @@
 (cl-defun mc/cycle (next-cursor fallback-cursor loop-message)
   (when (null next-cursor)
     (when (eql 'stop (mc/handle-loop-condition loop-message))
-      (return-from mc/cycle nil))
+      (cond
+       ((fboundp 'cl-return-from)
+        (cl-return-from mc/cycle nil))
+       ((fboundp 'return-from)
+        (return-from mc/cycle nil))))
     (setf next-cursor fallback-cursor))
   (mc/create-fake-cursor-at-point)
   (mc/pop-state-from-overlay next-cursor)


### PR DESCRIPTION
This removes the deprecation warning around `return-from'