### PR TITLE
Add homepage

### DIFF
--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -5,6 +5,7 @@
 ;; Author: Magnar Sveen <magnars@gmail.com>
 ;; Version: 1.4.0
 ;; Keywords: editing cursors
+;; Homepage: https://github.com/magnars/multiple-cursors.el
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
I noticed when browsing some packages a moment ago that there was no homepage defined in the head for mc.

Apologies if this is unwanted — it appears not to exist in many of your (excellent) repos (neither s nor er, but present in dash) so maybe it is intentional?