### PR TITLE
Revive hook `multiple-cursors-mode-disabled-hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ You can [watch an intro to multiple-cursors at Emacs Rocks](http://emacsrocks.co
 - If you would like to keep the global bindings clean, and get custom keybindings
   when the region is active, you can try [region-bindings-mode](https://github.com/fgallina/region-bindings-mode).
 
+- There is a special hook that is run when the mode is diabled
+  (which is equivalent to the number of cursors going back to 1):
+  `multiple-cursors-mode-disabled-hook`
+
 BTW, I highly recommend adding `mc/mark-next-like-this` to a key binding that's
 right next to the key for `er/expand-region`.
 

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -355,9 +355,7 @@ With zero ARG, skip the last one and mark next."
        (when point-first (exchange-point-and-mark)))))
   (if (> (mc/num-cursors) 1)
       (multiple-cursors-mode 1)
-    (progn
-      (multiple-cursors-mode 0)
-      (run-hooks 'multiple-cursors-mode-disabled-hook))))
+    (mc/disable-multiple-cursors-mode)))
 
 (defun mc--select-thing-at-point (thing)
   (let ((bound (bounds-of-thing-at-point thing)))
@@ -404,9 +402,7 @@ With zero ARG, skip the last one and mark next."
             (mc/pop-state-from-overlay first)))
         (if (> (mc/num-cursors) 1)
             (multiple-cursors-mode 1)
-          (progn
-            (multiple-cursors-mode 0)
-            (run-hooks 'multiple-cursors-mode-disabled-hook)))))))
+          (mc/disable-multiple-cursors-mode))))))
 
 ;;;###autoload
 (defun mc/mark-all-in-region-regexp (beg end)
@@ -431,9 +427,7 @@ With zero ARG, skip the last one and mark next."
             (error "Search failed for %S" search)))
         (goto-char (match-end 0))
         (if (< (mc/num-cursors) 3)
-            (progn
-              (multiple-cursors-mode 0)
-              (run-hooks 'multiple-cursors-mode-disabled-hook))
+            (mc/disable-multiple-cursors-mode)
           (mc/pop-state-from-overlay (mc/furthest-cursor-before-point))
           (multiple-cursors-mode 1))))))
 

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -355,7 +355,9 @@ With zero ARG, skip the last one and mark next."
        (when point-first (exchange-point-and-mark)))))
   (if (> (mc/num-cursors) 1)
       (multiple-cursors-mode 1)
-    (multiple-cursors-mode 0)))
+    (progn
+      (multiple-cursors-mode 0)
+      (run-hooks 'multiple-cursors-mode-disabled-hook))))
 
 (defun mc--select-thing-at-point (thing)
   (let ((bound (bounds-of-thing-at-point thing)))
@@ -402,7 +404,9 @@ With zero ARG, skip the last one and mark next."
             (mc/pop-state-from-overlay first)))
         (if (> (mc/num-cursors) 1)
             (multiple-cursors-mode 1)
-          (multiple-cursors-mode 0))))))
+          (progn
+            (multiple-cursors-mode 0)
+            (run-hooks 'multiple-cursors-mode-disabled-hook)))))))
 
 ;;;###autoload
 (defun mc/mark-all-in-region-regexp (beg end)
@@ -427,7 +431,9 @@ With zero ARG, skip the last one and mark next."
             (error "Search failed for %S" search)))
         (goto-char (match-end 0))
         (if (< (mc/num-cursors) 3)
-            (multiple-cursors-mode 0)
+            (progn
+              (multiple-cursors-mode 0)
+              (run-hooks 'multiple-cursors-mode-disabled-hook))
           (mc/pop-state-from-overlay (mc/furthest-cursor-before-point))
           (multiple-cursors-mode 1))))))
 

--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -106,8 +106,7 @@
       (progn
         (mc/mark-next-lines 1)
         (mc/reverse-regions)
-        (multiple-cursors-mode 0)
-        (multiple-cursors-mode-disabled-hook)
+        (mc/disable-multiple-cursors-mode)
         )
     (unless (use-region-p)
       (mc/execute-command-for-all-cursors 'mark-sexp))

--- a/mc-separate-operations.el
+++ b/mc-separate-operations.el
@@ -106,7 +106,9 @@
       (progn
         (mc/mark-next-lines 1)
         (mc/reverse-regions)
-        (multiple-cursors-mode 0))
+        (multiple-cursors-mode 0)
+        (multiple-cursors-mode-disabled-hook)
+        )
     (unless (use-region-p)
       (mc/execute-command-for-all-cursors 'mark-sexp))
     (setq mc--strings-to-replace (nreverse (mc--ordered-region-strings)))

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -433,9 +433,7 @@ the original cursor, to inform about the lack of support."
   (unless mc--executing-command-for-fake-cursor
 
     (if (eq 1 (mc/num-cursors)) ;; no fake cursors? disable mc-mode
-        (progn
-          (multiple-cursors-mode 0)
-          (run-hooks 'multiple-cursors-mode-disabled-hook))
+        (mc/disable-multiple-cursors-mode)
       (when this-original-command
         (let ((original-command (or mc--this-command
                                     (command-remapping this-original-command)
@@ -489,9 +487,7 @@ you should disable multiple-cursors-mode."
   "Deactivate mark if there are any active, otherwise exit multiple-cursors-mode."
   (interactive)
   (if (not (use-region-p))
-      (progn
-        (multiple-cursors-mode 0)
-        (run-hooks 'multiple-cursors-mode-disabled-hook))
+      (mc/disable-multiple-cursors-mode)
     (deactivate-mark)))
 
 (defun mc/repeat-command ()
@@ -592,18 +588,18 @@ They are temporarily disabled when multiple-cursors are active.")
     (mc/enable-temporarily-disabled-minor-modes)
     (run-hooks 'multiple-cursors-mode-disabled-hook)))
 
-(add-hook 'after-revert-hook
-          #'(lambda () (progn
-                         (multiple-cursors-mode 0)
-                         (run-hooks 'multiple-cursors-mode-disabled-hook))))
+(defun mc/disable-multiple-cursors-mode ()
+  "Disable multiple-cursors-mode and run the corresponding hook."
+  (multiple-cursors-mode 0)
+  (run-hooks 'multiple-cursors-mode-disabled-hook))
+
+(add-hook 'after-revert-hook 'mc/disable-multiple-cursors-mode)
 
 (defun mc/maybe-multiple-cursors-mode ()
   "Enable multiple-cursors-mode if there is more than one currently active cursor."
   (if (> (mc/num-cursors) 1)
       (multiple-cursors-mode 1)
-    (progn
-      (multiple-cursors-mode 0)
-      (run-hooks 'multiple-cursors-mode-disabled-hook))))
+    (mc/disable-multiple-cursors-mode)))
 
 (defmacro unsupported-cmd (cmd msg)
   "Adds command to list of unsupported commands and prevents it

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -433,7 +433,9 @@ the original cursor, to inform about the lack of support."
   (unless mc--executing-command-for-fake-cursor
 
     (if (eq 1 (mc/num-cursors)) ;; no fake cursors? disable mc-mode
-        (multiple-cursors-mode 0)
+        (progn
+          (multiple-cursors-mode 0)
+          (run-hooks 'multiple-cursors-mode-disabled-hook))
       (when this-original-command
         (let ((original-command (or mc--this-command
                                     (command-remapping this-original-command)
@@ -487,7 +489,9 @@ you should disable multiple-cursors-mode."
   "Deactivate mark if there are any active, otherwise exit multiple-cursors-mode."
   (interactive)
   (if (not (use-region-p))
-      (multiple-cursors-mode 0)
+      (progn
+        (multiple-cursors-mode 0)
+        (run-hooks 'multiple-cursors-mode-disabled-hook))
     (deactivate-mark)))
 
 (defun mc/repeat-command ()
@@ -588,13 +592,18 @@ They are temporarily disabled when multiple-cursors are active.")
     (mc/enable-temporarily-disabled-minor-modes)
     (run-hooks 'multiple-cursors-mode-disabled-hook)))
 
-(add-hook 'after-revert-hook #'(lambda () (multiple-cursors-mode 0)))
+(add-hook 'after-revert-hook
+          #'(lambda () (progn
+                         (multiple-cursors-mode 0)
+                         (run-hooks 'multiple-cursors-mode-disabled-hook))))
 
 (defun mc/maybe-multiple-cursors-mode ()
   "Enable multiple-cursors-mode if there is more than one currently active cursor."
   (if (> (mc/num-cursors) 1)
       (multiple-cursors-mode 1)
-    (multiple-cursors-mode 0)))
+    (progn
+      (multiple-cursors-mode 0)
+      (run-hooks 'multiple-cursors-mode-disabled-hook))))
 
 (defmacro unsupported-cmd (cmd msg)
   "Adds command to list of unsupported commands and prevents it


### PR DESCRIPTION
In the code I [found multiple references](https://github.com/magnars/multiple-cursors.el/search?q=multiple-cursors-mode-disabled-hook) to a`multiple-cursors-mode-disabled-hook`.

This promised to be very useful to me, so I tried it. But the hook doesn't work reliably. This is because multiple-cursors-mode is disabled within this repo at serveral places and most of them don't run the hook.

So I decided to fix those up and make the hook useful again. This branch is working fine for me and the hook is, too. I am a beginner with elisp, though. Therefore I am especially open for suggestions and feedback.

I hope this will get merged (even though I understand that this repo is in low-maintenance mode) because it is just a fix of a feature that (I suppose) was once working and got forgotten. I really don't want to maintain a fork just for a bugfix that might be usefull for others as well.

I would also like to thank you for this amazing package which is a great part of my workflow.