### PR TITLE
eliminate byte-compilation warnings

### DIFF
--- a/mc-cycle-cursors.el
+++ b/mc-cycle-cursors.el
@@ -92,7 +92,7 @@
        ((fboundp 'cl-return-from)
         (cl-return-from mc/cycle nil))
        ((fboundp 'return-from)
-        (return-from mc/cycle nil))))
+        (cl-return-from mc/cycle nil))))
     (setf next-cursor fallback-cursor))
   (mc/create-fake-cursor-at-point)
   (mc/pop-state-from-overlay next-cursor)

--- a/mc-hide-unmatched-lines-mode.el
+++ b/mc-hide-unmatched-lines-mode.el
@@ -54,8 +54,9 @@ also hum/lines-to-expand below and above) To make use of this
 mode press \"C-'\" while multiple-cursor-mode is active. You can
 still edit lines while you are in mc-hide-unmatched-lines
 mode. To leave this mode press <return> or \"C-g\""
-  nil " hu"
-  hum/hide-unmatched-lines-mode-map
+  :init-value nil
+  :lighter " hu"
+  :keymap hum/hide-unmatched-lines-mode-map
   (if mc-hide-unmatched-lines-mode
       ;;just in case if mc mode will be disabled while hide-unmatched-lines is active
       (progn

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -210,9 +210,13 @@ With zero ARG, skip the last one and mark next."
 
 ;;;###autoload
 (defun mc/mark-previous-like-this (arg)
-  "Find and mark the previous part of the buffer matching the currently active region
-If no region is active add a cursor on the previous line
+  "Find and mark the previous part of the buffer matching the
+currently active region.
+
+If no region is active ,add a cursor on the previous line.
+
 With negative ARG, delete the last one instead.
+
 With zero ARG, skip the last one and mark next."
   (interactive "p")
   (if (< arg 0)
@@ -227,9 +231,14 @@ With zero ARG, skip the last one and mark next."
 
 ;;;###autoload
 (defun mc/mark-previous-like-this-word (arg)
-  "Find and mark the previous part of the buffer matching the currently active region
-If no region is active, mark the word at the point and find the previous match
+  "Find and mark the previous part of the buffer matching the
+currently active region.
+
+If no region is active, mark the word at the point and find the
+previous match.
+
 With negative ARG, delete the last one instead.
+
 With zero ARG, skip the last one and mark previous."
   (interactive "p")
   (if (< arg 0)
@@ -244,9 +253,14 @@ With zero ARG, skip the last one and mark previous."
   (mc/maybe-multiple-cursors-mode))
 
 (defun mc/mark-previous-like-this-symbol (arg)
-  "Find and mark the previous part of the buffer matching the currently active region
-If no region is active, mark the symbol at the point and find the previous match
+  "Find and mark the previous part of the buffer matching the
+currently active region.
+
+If no region is active, mark the symbol at the point and find the
+previous match.
+
 With negative ARG, delete the last one instead.
+
 With zero ARG, skip the last one and mark previous."
   (interactive "p")
   (if (< arg 0)
@@ -263,10 +277,15 @@ With zero ARG, skip the last one and mark previous."
 
 ;;;###autoload
 (defun mc/mark-previous-word-like-this (arg)
-  "Find and mark the previous part of the buffer matching the currently active region
-The matching region must be a whole word to be a match
-If no region is active add a cursor on the previous line
+  "Find and mark the previous part of the buffer matching the
+currently active region.
+
+The matching region must be a whole word to be a match.
+
+If no region is active, add a cursor on the previous line.
+
 With negative ARG, delete the last one instead.
+
 With zero ARG, skip the last one and mark next."
   (interactive "p")
   (let ((mc/enclose-search-term 'words))
@@ -274,10 +293,15 @@ With zero ARG, skip the last one and mark next."
 
 ;;;###autoload
 (defun mc/mark-previous-symbol-like-this (arg)
-  "Find and mark the previous part of the buffer matching the currently active region
-The matching region must be a whole symbol to be a match
-If no region is active add a cursor on the previous line
+  "Find and mark the previous part of the buffer matching
+the currently active region.
+
+The matching region must be a whole symbol to be a match.
+
+If no region is active add a cursor on the previous line.
+
 With negative ARG, delete the last one instead.
+
 With zero ARG, skip the last one and mark next."
   (interactive "p")
   (let ((mc/enclose-search-term 'symbols))
@@ -324,13 +348,15 @@ With zero ARG, skip the last one and mark next."
 
 ;;;###autoload
 (defun mc/skip-to-next-like-this ()
-  "Skip the current one and select the next part of the buffer matching the currently active region."
+  "Skip the current one and select the next part of the buffer
+matching the currently active region."
   (interactive)
   (mc/mark-next-like-this 0))
 
 ;;;###autoload
 (defun mc/skip-to-previous-like-this ()
-  "Skip the current one and select the prev part of the buffer matching the currently active region."
+  "Skip the current one and select the prev part of the buffer
+matching the currently active region."
   (interactive)
   (mc/mark-previous-like-this 0))
 
@@ -471,7 +497,7 @@ remove the keymap depends on user input and KEEP-PRED:
 
 ;;;###autoload
 (defun mc/mark-more-like-this-extended ()
-  "Like mark-more-like-this, but then lets you adjust with arrows key.
+  "Like mark-more-like-this, but then lets you adjust with arrow keys.
 The adjustments work like this:
 
    <up>    Mark previous like this and set direction to 'up
@@ -487,13 +513,15 @@ If direction is 'down:
    <left>  Remove the cursor furthest down
    <right> Skip past the cursor furthest down
 
-The bindings for these commands can be changed. See `mc/mark-more-like-this-extended-keymap'."
+The bindings for these commands can be changed.
+See `mc/mark-more-like-this-extended-keymap'."
   (interactive)
   (mc/mmlte--down)
-  (set-temporary-overlay-map mc/mark-more-like-this-extended-keymap t))
+  (set-transient-map mc/mark-more-like-this-extended-keymap t))
 
 (defvar mc/mark-more-like-this-extended-direction nil
-  "When using mc/mark-more-like-this-extended are we working on the next or previous cursors?")
+  "When using mc/mark-more-like-this-extended
+are we working on the next or previous cursors?")
 
 (make-variable-buffer-local 'mc/mark-more-like-this-extended)
 
@@ -639,7 +667,7 @@ If the region is inactive or on a single line, it will behave like
    (last
     (progn
       (when (looking-at "<") (forward-char 1))
-      (when (looking-back ">") (forward-char -1))
+      (when (looking-back ">" 100) (forward-char -1))
       (sgml-get-context)))))
 
 (defun mc--on-tag-name-p ()

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -138,7 +138,7 @@ rendered or shift text."
   "Create overlay to look like cursor at end of line."
   (let ((overlay (make-overlay pos pos nil nil nil)))
     (if (and mc/match-cursor-style (mc/cursor-is-bar))
-	(overlay-put overlay 'before-string (propertize "|" 'face 'mc/cursor-bar-face))
+  (overlay-put overlay 'before-string (propertize "|" 'face 'mc/cursor-bar-face))
       (overlay-put overlay 'after-string (propertize " " 'face 'mc/cursor-face)))
     overlay))
 
@@ -146,7 +146,7 @@ rendered or shift text."
   "Create overlay to look like cursor inside text."
   (let ((overlay (make-overlay pos (1+ pos) nil nil nil)))
     (if (and mc/match-cursor-style (mc/cursor-is-bar))
-	(overlay-put overlay 'before-string (propertize "|" 'face 'mc/cursor-bar-face))
+  (overlay-put overlay 'before-string (propertize "|" 'face 'mc/cursor-bar-face))
       (overlay-put overlay 'face 'mc/cursor-face))
     overlay))
 
@@ -192,8 +192,8 @@ highlights the entire width of the window."
   "Store relevant info about point and mark in the given overlay."
   (overlay-put o 'point (set-marker (make-marker) (point)))
   (overlay-put o 'mark (set-marker (make-marker)
-				   (let ((mark-even-if-inactive t))
-				     (mark))))
+           (let ((mark-even-if-inactive t))
+             (mark))))
   (dolist (var mc/cursor-specific-vars)
     (when (boundp var) (overlay-put o var (symbol-value var))))
   o)
@@ -250,8 +250,11 @@ If this value is nil, there is no ceiling."
   :group 'multiple-cursors)
 
 (defun mc/create-fake-cursor-at-point (&optional id)
-  "Add a fake cursor and possibly a fake active region overlay based on point and mark.
-Saves the current state in the overlay to be restored later."
+  "Add a fake cursor and possibly a fake active region overlay
+based on point and mark.
+
+Saves the current state in the overlay
+to be restored later."
   (unless mc--max-cursors-original
     (setq mc--max-cursors-original mc/max-cursors))
   (when mc/max-cursors
@@ -271,7 +274,8 @@ Saves the current state in the overlay to be restored later."
     overlay))
 
 (defun mc/execute-command (cmd)
-  "Run command, simulating the parts of the command loop that makes sense for fake cursors."
+  "Run command, simulating the parts of the command loop that
+makes sense for fake cursors."
   (setq this-command cmd)
   (run-hooks 'pre-command-hook)
   (unless (eq this-command 'ignore)
@@ -350,7 +354,8 @@ cursor with updated info."
   "Variable to keep the state of the real cursor while undoing a fake one")
 
 (defun activate-cursor-for-undo (id)
-  "Called when undoing to temporarily activate the fake cursor which action is being undone."
+  "Called when undoing to temporarily activate the fake cursor
+which action is being undone."
   (let ((cursor (mc/cursor-with-id id)))
     (when cursor
       (setq mc--stored-state-for-undo (mc/store-current-state-in-overlay
@@ -567,13 +572,16 @@ They are temporarily disabled when multiple-cursors are active.")
   `(" mc:" (:eval (format ,(propertize "%d" 'face 'font-lock-warning-face)
                           (mc/num-cursors))))
   "What to display in the mode line while multiple-cursors-mode is active."
+  :type '(sexp)
   :group 'multiple-cursors)
 (put 'mc/mode-line 'risky-local-variable t)
 
 ;;;###autoload
 (define-minor-mode multiple-cursors-mode
   "Mode while multiple cursors are active."
-  nil mc/mode-line mc/keymap
+  :init-value nil
+  :lighter mc/mode-line
+  :keymap mc/keymap
   (if multiple-cursors-mode
       (progn
         (mc/temporarily-disable-unsupported-minor-modes)
@@ -617,7 +625,7 @@ from being executed if in multiple-cursors-mode."
 
 ;; Make sure pastes from other programs are added to all kill-rings when yanking
 (defadvice current-kill (before interprogram-paste-for-all-cursors
-				(n &optional do-not-move) activate)
+        (n &optional do-not-move) activate)
   (let ((interprogram-paste (and (= n 0)
                                  interprogram-paste-function
                                  (funcall interprogram-paste-function))))
@@ -693,8 +701,8 @@ for running commands with multiple cursors."
                                      mc/edit-ends-of-lines
                                      mc/edit-beginnings-of-lines
                                      mc/mark-next-like-this
-				     mc/mark-next-like-this-word
-				     mc/mark-next-like-this-symbol
+                                     mc/mark-next-like-this-word
+                                     mc/mark-next-like-this-symbol
                                      mc/mark-next-word-like-this
                                      mc/mark-next-symbol-like-this
                                      mc/mark-previous-like-this
@@ -713,7 +721,7 @@ for running commands with multiple cursors."
                                      mc/mark-all-dwim
                                      mc/mark-sgml-tag-pair
                                      mc/insert-numbers
-				     mc/insert-letters
+                                     mc/insert-letters
                                      mc/sort-regions
                                      mc/reverse-regions
                                      mc/cycle-forward

--- a/rectangular-region-mode.el
+++ b/rectangular-region-mode.el
@@ -52,8 +52,9 @@
 (defun set-rectangular-region-anchor ()
   "Anchors the rectangular region at point.
 
-Think of this one as `set-mark' except you're marking a rectangular region. It is
-an exceedingly quick way of adding multiple cursors to multiple lines."
+Think of this one as `set-mark' except you're marking a
+rectangular region. It is an exceedingly quick way of adding
+multiple cursors to multiple lines."
   (interactive)
   (set-marker rrm/anchor (point))
   (push-mark (point))
@@ -111,7 +112,9 @@ an exceedingly quick way of adding multiple cursors to multiple lines."
 ;;;###autoload
 (define-minor-mode rectangular-region-mode
   "A mode for creating a rectangular region to edit"
-  nil " rr" rectangular-region-mode-map
+  :init-value nil
+  :lighter " rr"
+  :keymap rectangular-region-mode-map
   (if rectangular-region-mode
       (progn
         (add-hook 'after-change-functions 'rrm/switch-to-multiple-cursors t t)


### PR DESCRIPTION
Emacs 28 aggressively attempts to byte-compile everything and it is noisy about warnings. Here are some edits to eliminate warnings in the multiple-cursors package. No functional changes. Test suite behaves identically before & after.

- long docstrings
- "defcustom fails to specify type" - use '(sexp)
- keyword arguments in define-minor-mode
- deprecations