### PR TITLE
support undo-fu commands

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -753,6 +753,8 @@ for running commands with multiple cursors."
                                      redo
                                      undo-tree-undo
                                      undo-tree-redo
+                                     undo-fu-only-undo
+                                     undo-fu-only-redo
                                      universal-argument
                                      universal-argument-more
                                      universal-argument-other-key


### PR DESCRIPTION
To fix the error for [undo-fu](https://github.com/emacsmirror/undo-fu
) users by default: 
`[mc] problem in ‘mc/execute-this-command-for-all-cursors’: Marker does not point anywhere`






