### PR TITLE
Detect cursor bar type when specified by the frame.

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -122,9 +122,13 @@ rendered or shift text."
 
 (defun mc/cursor-is-bar ()
   "Return non-nil if the cursor is a bar."
-  (or (eq cursor-type 'bar)
-    (and (listp cursor-type)
-         (eq (car cursor-type) 'bar))))
+  (let ((cursor-type
+         (if (eq cursor-type t)
+             (frame-parameter nil 'cursor-type)
+           cursor-type)))
+    (or (eq cursor-type 'bar)
+        (and (listp cursor-type)
+             (eq (car cursor-type) 'bar)))))
 
 (defun mc/line-number-at-pos (&optional pos absolute)
   "Faster implementation of `line-number-at-pos'."


### PR DESCRIPTION
When the 'cursor-type' for the buffer is specified by the frame, this was not detected by the current logic as 'cursor-type' will be set to 't' and thus not explicitly match 'bar'.  This update checks to see if 'cursor-type' is specified by the frame and will pull the parameter from the frame if it is, prior to subsequent checks.