### PR TITLE
Fix various problems with CI and test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       run: git clone https://github.com/cask/cask ~/.cask
     - name: Add Cask to PATH
       run: echo "$HOME/.cask/bin" >> $GITHUB_PATH
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies with Cask
       run: cask
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.3
-          - 24.4
-          - 24.5
           - 25.1
           - 25.2
           - 25.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
     - name: Install Cask
-      run: curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+      run: git clone https://github.com/cask/cask ~/.cask
     - name: Add Cask to PATH
       run: echo "$HOME/.cask/bin" >> $GITHUB_PATH
     - uses: actions/checkout@v2

--- a/mc-edit-lines.el
+++ b/mc-edit-lines.el
@@ -50,7 +50,7 @@ that symbol is used instead of `mc/edit-lines-empty-lines'.
 Otherwise, if ARG negative, short lines will be ignored.  Any
 other non-nil value will cause short lines to be padded."
   (interactive "P")
-  (when (not (and mark-active (/= (point) (mark))))
+  (unless mark-active
     (error "Mark a set of lines first"))
   (mc/remove-fake-cursors)
   (let* ((col (current-column))

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -669,7 +669,7 @@ If the region is inactive or on a single line, it will behave like
    (last
     (progn
       (when (looking-at "<") (forward-char 1))
-      (when (looking-back ">" 100) (forward-char -1))
+      (when (looking-back ">" 1) (forward-char -1))
       (sgml-get-context)))))
 
 (defun mc--on-tag-name-p ()


### PR DESCRIPTION
This PR does multiple things that should result in the CI working again:

+ Change the CI configuration to use the new Cask installation method
+ Change the CI to use actions/checkout@v3
+ Fix some problems that I found by running the CI suite
+ Drop CI support for Emacs 24.x versions as they are not properly supported by Cask anymore (cask/cask@685c4c1)

I hope it was okay to combine these changes in one PR.