### PR TITLE
Add multiple-cursors support to execute-extended-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ To get out of multiple-cursors-mode, press `<return>` or `C-g`. The latter will
 first disable multiple regions before disabling multiple cursors. If you want to
 insert a newline in multiple-cursors-mode, use `C-j`.
 
-## Important note
-
-Multiple cursors does not do well when you invoke its commands with `M-x`. It needs to be bound to keys to work properly. Pull request to fix this is welcome.
-
 ## Video
 
 You can [watch an intro to multiple-cursors at Emacs Rocks](http://emacsrocks.com/e13.html).
@@ -204,7 +200,6 @@ run once to `mc/cmds-to-run-once` in ".mc-lists.el".
 
 * isearch-forward and isearch-backward aren't supported with multiple cursors.
   If you want this functionality, you can use [phi-search](https://github.com/zk-phi/phi-search).
-* Commands run with `M-x` won't be repeated for all cursors.
 * All key bindings that refer to lambdas are always run for all cursors. If you
   need to limit it, you will have to give it a name.
 * Redo might screw with your cursors. Undo works very well.

--- a/features/multiple-cursors-core.feature
+++ b/features/multiple-cursors-core.feature
@@ -57,6 +57,28 @@ Feature: Multiple cursors core
     And I press "C-!"
     Then I should see "This aatext contains the word text twice"
 
+  Scenario: Multiple supported M-x command (forward-word in this case)
+    Given I have cursors at "text" in "This text contains the word text twice"
+    And I type "("
+    And I press "M-x forward-word"
+    And I press "M-x forward-word"
+    And I type ")"
+    Then I should see "This (text contains) the word (text twice)"
+
+  Scenario: Unknown M-x command: yes, do for all
+    Given I have cursors at "text" in "This text contains the word text twice"
+    And I press "C-SPC"
+    And I press "M-f"
+    And I press "M-x upcase-dwim RET y"
+    Then I should see "This TEXT contains the word TEXT twice"
+
+  Scenario: Unknown M-x command: no, don't do for all
+    Given I have cursors at "text" in "This text contains the word text twice"
+    And I press "C-SPC"
+    And I press "M-f"
+    And I press "M-x upcase-dwim RET n"
+    Then I should see "This TEXT contains the word text twice"
+
   Scenario: Undo
     Given I have cursors at "text" in "This text contains the word text twice"
     When I press "M-f"

--- a/features/repeat-command.feature
+++ b/features/repeat-command.feature
@@ -8,6 +8,7 @@ Feature: Repeat last interactive command for fake cursors (mc/repeat-command)
     And I press "RET"
     And I type "21"
     And I press "RET"
+    And I type "n"
     And I press "C-:"
     And I press "y"
     And I execute the action chain
@@ -27,6 +28,7 @@ Feature: Repeat last interactive command for fake cursors (mc/repeat-command)
   Scenario: Disable prompt
     Given I have cursors at "text" in "This text/0000 contains the word text/1111 thrice (text/2222)"
     When I set mc/always-repeat-command to t
+    When I set mc/always-run-for-all to t
     When I start an action chain
     And I press "M-x"
     And I type "zap-to-char"

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -45,6 +45,8 @@
  (subword-mode 0)
  (wrap-region-mode 0)
  (setq set-mark-default-inactive nil)
- (deactivate-mark))
+ (deactivate-mark)
+ (setq mc/cmds-to-run-for-all nil)
+ (setq mc/cmds-to-run-once nil))
 
 (After)

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -664,6 +664,20 @@ from being executed if in multiple-cursors-mode."
            (overlay-put cursor 'kill-ring kill-ring)
            (overlay-put cursor 'kill-ring-yank-pointer kill-ring-yank-pointer)))))))
 
+(defadvice execute-extended-command (after execute-extended-command-for-all-cursors () activate)
+  (when multiple-cursors-mode
+    (unless (or mc/always-run-for-all
+                (not (symbolp this-command))
+                (memq this-command mc/cmds-to-run-for-all)
+                (memq this-command mc/cmds-to-run-once)
+                (memq this-command mc--default-cmds-to-run-for-all)
+                (memq this-command mc--default-cmds-to-run-once))
+      (mc/prompt-for-inclusion-in-whitelist this-command))
+    (when (or mc/always-run-for-all
+              (memq this-command mc/cmds-to-run-for-all)
+              (memq this-command mc--default-cmds-to-run-for-all))
+      (mc/execute-command-for-all-fake-cursors this-command))))
+
 (defcustom mc/list-file (locate-user-emacs-file ".mc-lists.el")
   "The position of the file that keeps track of your preferences
 for running commands with multiple cursors."

--- a/multiple-cursors.el
+++ b/multiple-cursors.el
@@ -153,7 +153,6 @@
 
 ;; * isearch-forward and isearch-backward aren't supported with multiple cursors.
 ;;   You should feel free to add a simplified version that can work with it.
-;; * Commands run with `M-x` won't be repeated for all cursors.
 ;; * All key bindings that refer to lambdas are always run for all cursors. If you
 ;;   need to limit it, you will have to give it a name.
 ;; * Redo might screw with your cursors. Undo works very well.


### PR DESCRIPTION
This PR adds multiple-cursors support to `execute-extended-command`, as well as three tests to ensure this new feature is working correctly. Some other tests and the test harness are adapted to the fact that unknown `M-x` commands will now prompt the user for inclusion into the whitelist.

One issue with this approach is that it can only support packages that override `M-x` when they still use `execute-extended-command` for actually running their commands. So, for example, [`amx`](https://github.com/DarwinAwardWinner/amx/blob/master/amx.el#L401) will work fine while [`counsel-M-x`](https://github.com/abo-abo/swiper/blob/master/counsel.el#L923) will not.

I don't really see how to adapt this feature to be generic for all possible ways to override `M-x`, so maybe we should add a note about that to the README. However, this should be an easy fix on the side of packages that override `M-x`, so it might be worth trying to contribute fixes to counsel and similar packages.