### PR TITLE
Support commands with multiple read-chars

### DIFF
--- a/features/multiple-cursors-core.feature
+++ b/features/multiple-cursors-core.feature
@@ -50,6 +50,13 @@ Feature: Multiple cursors core
     And I press "C-!"
     Then I should see "This aatext contains the word aatext twice"
 
+Scenario: Unknown command with multiple read: yes, do for all
+    Given I have bound C-! to a new command that inserts two read-chars
+    And I have cursors at "text" in "This text contains the word text twice"
+    When I press "C-! b c y"
+    And I press "C-! d e"
+    Then I should see "This bcdetext contains the word bcdetext twice"
+
   Scenario: Unknown command: no, don't do for all
     Given I have bound C-! to another new command that inserts "a"
     And I have cursors at "text" in "This text contains the word text twice"

--- a/features/step-definitions/multiple-cursors-steps.el
+++ b/features/step-definitions/multiple-cursors-steps.el
@@ -130,6 +130,11 @@
            (defun mc-test-temp-command-2 () (interactive) (insert ins))
            (global-set-key (kbd "C-!") 'mc-test-temp-command-2))))
 
+(Given "^I have bound C-! to a new command that inserts two read-chars$"
+       (lambda ()
+         (defun mc-test-temp-command-3 () (interactive) (insert (read-char "first: ")) (insert (read-char "second: ")))
+         (global-set-key (kbd "C-!") 'mc-test-temp-command-3)))
+
 (Given "^I have bound C-! to a keyboard macro that insert \"_\"$"
        (lambda ()
          (fset 'mc-test-temp-kmacro "\C-q_")


### PR DESCRIPTION
This change fixes commands that read-chars multiple times. Previously, two stage commands like embrace-change would read the same char twice immediately and avy-goto-char-timer would never stop reading input as a cached value was always provided during the timer. Instead, the read-char prompt is included in the cache key so that multiple different calls are cached separately and accessible by the fake cursors.

rev2: It ooks like the build failed due to the `alist-get` so trying a rewrite with `assoc` https://github.com/emacs-mirror/emacs/blob/e2cc16fbd0d16e6c0ff59221af49e3d4113500cd/etc/NEWS.25#L1464