### PR TITLE
Fix byte compilation warnings

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -29,6 +29,9 @@
 
 (require 'multiple-cursors-core)
 (require 'thingatpt)
+(require 'sgml-mode)
+
+(defvar mc/mark-more-like-this-extended-keymap (make-sparse-keymap))
 
 (defun mc/cursor-end (cursor)
   (if (overlay-get cursor 'mark-active)
@@ -96,8 +99,8 @@ to (point)), or nil."
   "How should mc/mark-more-* search for more matches?
 
 Match everything: nil
-Match only whole words: 'words
-Match only whole symbols: 'symbols
+Match only whole words: \\='words
+Match only whole symbols: \\='symbols
 
 Use like case-fold-search, don't recommend setting it globally.")
 
@@ -502,15 +505,15 @@ remove the keymap depends on user input and KEEP-PRED:
   "Like mark-more-like-this, but then lets you adjust with arrow keys.
 The adjustments work like this:
 
-   <up>    Mark previous like this and set direction to 'up
-   <down>  Mark next like this and set direction to 'down
+   <up>    Mark previous like this and set direction to \\='up
+   <down>  Mark next like this and set direction to \\='down
 
-If direction is 'up:
+If direction is \\='up:
 
    <left>  Skip past the cursor furthest up
    <right> Remove the cursor furthest up
 
-If direction is 'down:
+If direction is \\='down:
 
    <left>  Remove the cursor furthest down
    <right> Skip past the cursor furthest down
@@ -557,8 +560,6 @@ are we working on the next or previous cursors?")
       (mc/unmark-previous-like-this)
     (mc/skip-to-next-like-this))
   (mc/mmlte--message))
-
-(defvar mc/mark-more-like-this-extended-keymap (make-sparse-keymap))
 
 (define-key mc/mark-more-like-this-extended-keymap (kbd "<up>") 'mc/mmlte--up)
 (define-key mc/mark-more-like-this-extended-keymap (kbd "<down>") 'mc/mmlte--down)

--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -31,8 +31,6 @@
 (require 'thingatpt)
 (require 'sgml-mode)
 
-(defvar mc/mark-more-like-this-extended-keymap (make-sparse-keymap))
-
 (defun mc/cursor-end (cursor)
   (if (overlay-get cursor 'mark-active)
       (max (overlay-get cursor 'point)
@@ -500,6 +498,13 @@ remove the keymap depends on user input and KEEP-PRED:
 
       (push alist emulation-mode-map-alists))))
 
+(defvar mc/mark-more-like-this-extended-keymap (make-sparse-keymap))
+
+(define-key mc/mark-more-like-this-extended-keymap (kbd "<up>") 'mc/mmlte--up)
+(define-key mc/mark-more-like-this-extended-keymap (kbd "<down>") 'mc/mmlte--down)
+(define-key mc/mark-more-like-this-extended-keymap (kbd "<left>") 'mc/mmlte--left)
+(define-key mc/mark-more-like-this-extended-keymap (kbd "<right>") 'mc/mmlte--right)
+
 ;;;###autoload
 (defun mc/mark-more-like-this-extended ()
   "Like mark-more-like-this, but then lets you adjust with arrow keys.
@@ -560,11 +565,6 @@ are we working on the next or previous cursors?")
       (mc/unmark-previous-like-this)
     (mc/skip-to-next-like-this))
   (mc/mmlte--message))
-
-(define-key mc/mark-more-like-this-extended-keymap (kbd "<up>") 'mc/mmlte--up)
-(define-key mc/mark-more-like-this-extended-keymap (kbd "<down>") 'mc/mmlte--down)
-(define-key mc/mark-more-like-this-extended-keymap (kbd "<left>") 'mc/mmlte--left)
-(define-key mc/mark-more-like-this-extended-keymap (kbd "<right>") 'mc/mmlte--right)
 
 (defvar mc--restrict-mark-all-to-symbols nil)
 

--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -334,7 +334,7 @@ values."
   (let ((mc-name (intern (concat "mc--" (symbol-name fn-name)))))
     `(progn
        (defun ,mc-name (orig-fun &rest args)
-         (if (not multiple-cursors-mode)
+         (if (not (bound-and-true-p multiple-cursors-mode))
              (apply orig-fun args)
            (let* ((cache-key (cons ,(symbol-name fn-name) (,args-cache-key-fn args)))
                   (cached-value (assoc cache-key mc--input-function-cache))


### PR DESCRIPTION
Hi, this PR fixes the following byte compilation warnings I encountered on `29.1`:

```
In mc--read-char:
multiple-cursors-core.el:347:2: Warning: reference to free variable ‘multiple-cursors-mode’

In mc--read-quoted-char:
multiple-cursors-core.el:348:2: Warning: reference to free variable ‘multiple-cursors-mode’

In mc--register-read-with-preview:
multiple-cursors-core.el:349:2: Warning: reference to free variable ‘multiple-cursors-mode’

In mc--read-char-from-minibuffer:
multiple-cursors-core.el:350:2: Warning: reference to free variable ‘multiple-cursors-mode’

In toplevel form:
mc-mark-more.el:95:2: Warning: defvar `mc/enclose-search-term' docstring has wrong usage of unescaped single quotes (use \= or different quoting)

In mc/mark-more-like-this-extended:
mc-mark-more.el:501:2: Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting) mc-mark-more.el:522:22: Warning: reference to free variable ‘mc/mark-more-like-this-extended-keymap’

In end of data:
mc-mark-more.el:724:27: Warning: the function ‘sgml-skip-tag-forward’ is not known to be defined. mc-mark-more.el:673:8: Warning: the function ‘sgml-get-context’ is not known to be defined.

In end of data:
mc-hide-unmatched-lines-mode.el:110:1: Warning: the function ‘sgml-skip-tag-forward’ is not known to be defined. mc-hide-unmatched-lines-mode.el:110:1: Warning: the function ‘sgml-get-context’ is not known to be defined.

In end of data:
multiple-cursors-core.el:567:43: Warning: the function ‘sgml-skip-tag-forward’ is not known to be defined. multiple-cursors-core.el:535:25: Warning: the function ‘sgml-get-context’ is not known to be defined.

In end of data:
mc-cycle-cursors.el:124:1: Warning: the function ‘sgml-skip-tag-forward’ is not known to be defined. mc-cycle-cursors.el:124:1: Warning: the function ‘sgml-get-context’ is not known to be defined.
```

Thanks!