### PR TITLE
Align version numbers

### DIFF
--- a/multiple-cursors-pkg.el
+++ b/multiple-cursors-pkg.el
@@ -1,3 +1,3 @@
-(define-package "multiple-cursors" "1.3.0"
+(define-package "multiple-cursors" "1.4.0"
   "Multiple cursors for Emacs."
   '((cl-lib "0.5")))


### PR DESCRIPTION
Version in `multiple-cursors-pkg.el` should be the same as in `multiple-cursors.el`,  namely `1.4.0`.

(In particular this fixes an issue I have with installing this repo via the elpaso Emacs package manager.)

Thanks for your consideration.