### PR TITLE
Add unsupported minor modes (nameless-mode, auto-save-visited-mode)

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -733,7 +733,7 @@ So you can paste it in later with `yank-rectangle'."
     (unless (mc--all-equal entries)
       (setq killed-rectangle entries))))
 
-(defvar mc/unsupported-minor-modes '(company-mode auto-complete-mode flyspell-mode jedi-mode)
+(defvar mc/unsupported-minor-modes '(company-mode auto-complete-mode flyspell-mode jedi-mode auto-save-visited-mode nameless-mode)
   "List of minor-modes that does not play well with multiple-cursors.
 They are temporarily disabled when multiple-cursors are active.")
 


### PR DESCRIPTION
These two behave quite badly in my experience. (nameless-mode & auto-save-visited-mode)

FYI: auto-save-visited-mode saves the buffer after 5 idle seconds, which has a tendency to execute a thousand-and-one unknown hooks that may reformat what's on screen etc.