### PR TITLE
Use symbol-value instead of eval

### DIFF
--- a/multiple-cursors-core.el
+++ b/multiple-cursors-core.el
@@ -743,7 +743,7 @@ They are temporarily disabled when multiple-cursors are active.")
 
 (defun mc/temporarily-disable-minor-mode (mode)
   "If MODE is available and turned on, remember that and turn it off."
-  (when (and (boundp mode) (eval mode))
+  (when (and (boundp mode) (symbol-value mode))
     (add-to-list 'mc/temporarily-disabled-minor-modes mode)
     (funcall mode -1)))
 


### PR DESCRIPTION
The Emacs Lisp manual says, "to get the value of a variable, while eval works, symbol-value is preferable".
