### PR TITLE
Remove redundant check of use-region-p

### DIFF
--- a/mc-mark-more.el
+++ b/mc-mark-more.el
@@ -56,7 +56,7 @@
     beg))
 
 (defun mc/furthest-cursor-before-point ()
-  (let ((beg (if (use-region-p) (use-region-beginning) (point)))
+  (let ((beg (or (use-region-beginning) (point)))
         furthest)
     (mc/for-each-fake-cursor
      (when (< (mc/cursor-beg cursor) beg)
@@ -65,7 +65,7 @@
     furthest))
 
 (defun mc/furthest-cursor-after-point ()
-  (let ((end (if (use-region-p) (use-region-end) (point)))
+  (let ((end (or (use-region-end) (point)))
         furthest)
     (mc/for-each-fake-cursor
      (when (> (mc/cursor-end cursor) end)


### PR DESCRIPTION
This is a [small simplification](https://lists.gnu.org/archive/html/emacs-devel/2026-04/msg00359.html) suggested by Stefan Monnier that removes a redundant check for `use-region-p` that is already performed in the `use-region-beginning` and `use-region-end` funcs.